### PR TITLE
dashboard import fails for large body

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ import_data() {
   set -e
   echo " "
   echo $1
-  curl -s -S -H 'Content-Type:application/json' -u $GF_USER:$GF_PASSWORD --data-raw "$2" ${GF_API}$3
+  echo "$2" | curl -s -S -H 'Content-Type:application/json' -u $GF_USER:$GF_PASSWORD --data @- ${GF_API}$3
   echo " "
   set +e
 }


### PR DESCRIPTION
Importing the current `pageSummary.json` fails:

```
grafana-setup_1  | /dashboards/pageSummary.json
grafana-setup_1  | /entrypoint.sh: line 64: curl: Argument list too long
```