### PR TITLE
Use same color scheme as WebPageTest for resources

### DIFF
--- a/dashboards/pageSummary.json
+++ b/dashboards/pageSummary.json
@@ -1908,7 +1908,15 @@
       "height": "350px",
       "panels": [
         {
-          "aliasColors": {},
+          "aliasColors": {
+            "css": "#b2ea94",
+            "flash": "#2db7c1",
+            "font": "#ff523e",
+            "html": "#82b5fc",
+            "image": "#c49ae8",
+            "js": "#fec584",
+            "other": "#c4c4c4"
+          },
           "bars": false,
           "datasource": "${DS_GRAPHITE}",
           "description": "The total transfer size by content type.",
@@ -1983,7 +1991,15 @@
           ]
         },
         {
-          "aliasColors": {},
+          "aliasColors": {
+            "css": "#b2ea94",
+            "flash": "#2db7c1",
+            "font": "#ff523e",
+            "html": "#82b5fc",
+            "image": "#c49ae8",
+            "js": "#fec584",
+            "other": "#c4c4c4"
+          },
           "bars": false,
           "datasource": "${DS_GRAPHITE}",
           "decimals": 0,

--- a/dashboards/wptPageSummary.json
+++ b/dashboards/wptPageSummary.json
@@ -788,7 +788,15 @@
       "title": "New row",
       "panels": [
         {
-          "aliasColors": {},
+          "aliasColors": {
+            "css": "#b2ea94",
+            "flash": "#2db7c1",
+            "font": "#ff523e",
+            "html": "#82b5fc",
+            "image": "#c49ae8",
+            "js": "#fec584",
+            "other": "#c4c4c4"
+          },
           "bars": false,
           "datasource": "${DS_GRAPHITE}",
           "editable": true,
@@ -861,7 +869,15 @@
           ]
         },
         {
-          "aliasColors": {},
+          "aliasColors": {
+            "css": "#b2ea94",
+            "flash": "#2db7c1",
+            "font": "#ff523e",
+            "html": "#82b5fc",
+            "image": "#c49ae8",
+            "js": "#fec584",
+            "other": "#c4c4c4"
+          },
           "bars": false,
           "datasource": "${DS_GRAPHITE}",
           "editable": true,


### PR DESCRIPTION
Use the same colors that [WebPageTest uses for color coding resource types](https://github.com/WPO-Foundation/webpagetest/blob/master/www/contentColors.inc#L74-L83).

I see that Chrome DevTools uses a new color scheme. It would be great if more tools use the same scheme. So this can change in the future.

![picture 2017-02-09 at 13 26 45](https://cloud.githubusercontent.com/assets/657797/22783420/fa5e4c76-eecb-11e6-94ce-01555679a3b5.jpg)