### PR TITLE
Add WPT dashboards

### DIFF
--- a/dashboards/graphite/WebPageTest3rdvs1stparty.json
+++ b/dashboards/graphite/WebPageTest3rdvs1stparty.json
@@ -11,8 +11,8 @@
     {
       "name": "VAR_PATH",
       "type": "constant",
-      "label": "desktop",
-      "value": "desktop",
+      "label": "default",
+      "value": "default",
       "description": ""
     },
     {
@@ -277,7 +277,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Poids : domaine principal VS domaines tiers",
+          "title": "Weight : main domain VS 3rd party domain",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -381,7 +381,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Requêtes par domaine tiers (top 10)",
+          "title": "Top 10 Number of requests from 3rd party domains",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -485,7 +485,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Poids par domaine tiers (top 10)",
+          "title": "Top 10 weight per 3rd party domain",
           "tooltip": {
             "msResolution": false,
             "shared": true,

--- a/dashboards/graphite/WebPageTest3rdvs1stparty.json
+++ b/dashboards/graphite/WebPageTest3rdvs1stparty.json
@@ -161,7 +161,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Requêtes : domaine principal VS domaines tiers",
+          "title": "Weight : main domain VS 3rd party domain",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -327,6 +327,7 @@
           "error": false,
           "fill": 4,
           "grid": {},
+          "height": 550,
           "id": 11,
           "legend": {
             "alignAsTable": true,
@@ -431,6 +432,7 @@
           "error": false,
           "fill": 4,
           "grid": {},
+          "height": 550,
           "id": 12,
           "legend": {
             "alignAsTable": true,

--- a/dashboards/graphite/WebPageTest3rdvs1stparty.json
+++ b/dashboards/graphite/WebPageTest3rdvs1stparty.json
@@ -1,0 +1,730 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GRAPHITE",
+      "label": "graphite",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "graphite",
+      "pluginName": "Graphite"
+    },
+    {
+      "name": "VAR_PATH",
+      "type": "constant",
+      "label": "desktop",
+      "value": "desktop",
+      "description": ""
+    },
+    {
+      "name": "VAR_BASE",
+      "type": "constant",
+      "label": "sitespeed_io",
+      "value": "sitespeed_io",
+      "description": ""
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.5.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "graphite",
+      "name": "Graphite",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 2,
+  "hideControls": true,
+  "id": 1,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {
+            "firstParty": "#7EB26D",
+            "requests": "#EAB839",
+            "thirdParty": "#890F02"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "decimals": 0,
+          "editable": true,
+          "error": false,
+          "fill": 4,
+          "grid": {},
+          "id": 1,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "requests",
+              "lines": false,
+              "stack": false,
+              "yaxis": 2
+            },
+            {
+              "alias": "firstParty"
+            }
+          ],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sitespeed_firstparty{value=\"requests\", metric=\"median\"}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "First Party",
+              "metric": "sitespeed_firstparty",
+              "refId": "A",
+              "step": 120,
+              "target": "alias($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domains.$domain.requests, '$domain')",
+              "textEditor": true
+            },
+            {
+              "expr": "sitespeed_thirdparty{value=\"requests\", metric=\"median\"}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Third party",
+              "metric": "sitespeed_thirdparty",
+              "refId": "B",
+              "step": 120,
+              "target": "alias(sumSeries($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domains.*.requests), 'Total')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Requêtes : domaine principal VS domaines tiers",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {
+            "firstParty": "#7EB26D",
+            "requests": "#EAB839",
+            "thirdParty": "#890F02"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "decimals": 0,
+          "editable": true,
+          "error": false,
+          "fill": 4,
+          "grid": {},
+          "id": 10,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "requests",
+              "lines": false,
+              "stack": false,
+              "yaxis": 2
+            },
+            {
+              "alias": "firstParty"
+            }
+          ],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sitespeed_firstparty{value=\"requests\", metric=\"median\"}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "First Party",
+              "metric": "sitespeed_firstparty",
+              "refId": "A",
+              "step": 120,
+              "target": "alias(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domains.$domain.bytes, '$domain')",
+              "textEditor": true
+            },
+            {
+              "expr": "sitespeed_thirdparty{value=\"requests\", metric=\"median\"}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Third party",
+              "metric": "sitespeed_thirdparty",
+              "refId": "B",
+              "step": 120,
+              "target": "alias(sumSeries(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domains.*.bytes), 'Total')",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Poids : domaine principal VS domaines tiers",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "decbytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {
+            "firstParty": "#7EB26D",
+            "requests": "#EAB839",
+            "thirdParty": "#890F02"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "decimals": 0,
+          "editable": true,
+          "error": false,
+          "fill": 4,
+          "grid": {},
+          "id": 11,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "requests",
+              "lines": false,
+              "stack": false,
+              "yaxis": 2
+            },
+            {
+              "alias": "firstParty"
+            }
+          ],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sitespeed_firstparty{value=\"requests\", metric=\"median\"}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "First Party",
+              "metric": "sitespeed_firstparty",
+              "refId": "A",
+              "step": 120,
+              "target": "limit(sortByMaxima(exclude(aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domains.*.requests, 12), '$domain')), 10)",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Requêtes par domaine tiers (top 10)",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {
+            "firstParty": "#7EB26D",
+            "requests": "#EAB839",
+            "thirdParty": "#890F02"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "decimals": 0,
+          "editable": true,
+          "error": false,
+          "fill": 4,
+          "grid": {},
+          "id": 12,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "requests",
+              "lines": false,
+              "stack": false,
+              "yaxis": 2
+            },
+            {
+              "alias": "firstParty"
+            }
+          ],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sitespeed_firstparty{value=\"requests\", metric=\"median\"}",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "First Party",
+              "metric": "sitespeed_firstparty",
+              "refId": "A",
+              "step": 120,
+              "target": "limit(sortByMaxima(exclude(aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domains.*.bytes, 12), '$domain')), 10)",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Poids par domaine tiers (top 10)",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "${VAR_BASE}",
+          "value": "${VAR_BASE}"
+        },
+        "hide": 2,
+        "label": "${VAR_BASE}",
+        "name": "base",
+        "options": [
+          {
+            "text": "${VAR_BASE}",
+            "value": "${VAR_BASE}"
+          }
+        ],
+        "query": "${VAR_BASE}",
+        "type": "constant"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "${VAR_PATH}",
+          "value": "${VAR_PATH}"
+        },
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "path",
+        "options": [],
+        "query": "$base.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "domain",
+        "options": [],
+        "query": "$base.$path.pageSummary.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "page",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "text": "webpagetest",
+          "value": "webpagetest"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "browser",
+        "options": [
+          {
+            "selected": true,
+            "text": "webpagetest",
+            "value": "webpagetest"
+          }
+        ],
+        "query": "webpagetest",
+        "type": "constant"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "local_xp_ie8-chrome",
+          "value": "local_xp_ie8-chrome"
+        },
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "location",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.$page.$browser.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "connectivity",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.$page.$browser.$location.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "text": "data.median.firstView",
+          "value": "data.median.firstView"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "run",
+        "options": [
+          {
+            "selected": true,
+            "text": "data.median.firstView",
+            "value": "data.median.firstView"
+          }
+        ],
+        "query": "data.median.firstView",
+        "type": "constant"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "WebPageTest 3rd vs 1st party",
+  "version": 15
+}

--- a/dashboards/graphite/WebPageTestCompareBetweenPages.json
+++ b/dashboards/graphite/WebPageTestCompareBetweenPages.json
@@ -11,8 +11,8 @@
     {
       "name": "VAR_PATH",
       "type": "constant",
-      "label": "desktop",
-      "value": "desktop",
+      "label": "default",
+      "value": "default",
       "description": ""
     },
     {

--- a/dashboards/graphite/WebPageTestCompareBetweenPages.json
+++ b/dashboards/graphite/WebPageTestCompareBetweenPages.json
@@ -28,7 +28,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.5.1"
+      "version": "4.6.0-beta3"
     },
     {
       "type": "panel",
@@ -41,18 +41,6 @@
       "id": "graphite",
       "name": "Graphite",
       "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
     }
   ],
   "annotations": {
@@ -72,7 +60,7 @@
   "gnetId": null,
   "graphTooltip": 2,
   "hideControls": false,
-  "id": 2,
+  "id": 7,
   "links": [],
   "rows": [
     {
@@ -113,7 +101,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.*.*.data.median.firstView.SpeedIndex, 3, 4)",
+              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.$location.$connectivity.$run.SpeedIndex, 3, 4)",
               "textEditor": true
             }
           ],
@@ -199,7 +187,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.*.*.data.median.firstView.requestsFull, 3, 4)"
+              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.$location.$connectivity.$run.requestsFull, 3, 4)",
+              "textEditor": true
             }
           ],
           "thresholds": [],
@@ -272,7 +261,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.*.*.data.median.firstView.bytesIn, 3, 4)"
+              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.$location.$connectivity.$run.bytesIn, 3, 4)",
+              "textEditor": true
             }
           ],
           "thresholds": [],
@@ -327,6 +317,7 @@
     "list": [
       {
         "current": {
+          "tags": [],
           "text": "${VAR_BASE}",
           "value": "${VAR_BASE}"
         },
@@ -335,6 +326,7 @@
         "name": "base",
         "options": [
           {
+            "selected": true,
             "text": "${VAR_BASE}",
             "value": "${VAR_BASE}"
           }
@@ -343,20 +335,124 @@
         "type": "constant"
       },
       {
+        "allValue": null,
         "current": {
           "text": "${VAR_PATH}",
           "value": "${VAR_PATH}"
         },
+        "datasource": "${DS_GRAPHITE}",
         "hide": 2,
-        "label": "${VAR_PATH}",
+        "includeAll": false,
+        "label": "",
+        "multi": false,
         "name": "path",
+        "options": [],
+        "query": "$base.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "domain",
+        "options": [],
+        "query": "$base.$path.pageSummary.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "page",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "location",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.$page.webpagetest.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "connectivity",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.$page.webpagetest.$location.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "text": "data.median.firstView",
+          "value": "data.median.firstView"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "run",
         "options": [
           {
-            "text": "${VAR_PATH}",
-            "value": "${VAR_PATH}"
+            "selected": true,
+            "text": "data.median.firstView",
+            "value": "data.median.firstView"
           }
         ],
-        "query": "${VAR_PATH}",
+        "query": "data.median.firstView",
         "type": "constant"
       }
     ]
@@ -391,6 +487,6 @@
     ]
   },
   "timezone": "",
-  "title": "WebPageTest Compare performance",
-  "version": 11
+  "title": "Compare performance",
+  "version": 36
 }

--- a/dashboards/graphite/WebPageTestCompareBetweenPages.json
+++ b/dashboards/graphite/WebPageTestCompareBetweenPages.json
@@ -487,6 +487,6 @@
     ]
   },
   "timezone": "",
-  "title": "Compare performance",
+  "title": "WebPagetest Compare performance",
   "version": 36
 }

--- a/dashboards/graphite/WebPageTestCompareBetweenPages.json
+++ b/dashboards/graphite/WebPageTestCompareBetweenPages.json
@@ -1,0 +1,396 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GRAPHITE",
+      "label": "graphite",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "graphite",
+      "pluginName": "Graphite"
+    },
+    {
+      "name": "VAR_PATH",
+      "type": "constant",
+      "label": "desktop",
+      "value": "desktop",
+      "description": ""
+    },
+    {
+      "name": "VAR_BASE",
+      "type": "constant",
+      "label": "sitespeed_io",
+      "value": "sitespeed_io",
+      "description": ""
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.5.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "graphite",
+      "name": "Graphite",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 2,
+  "hideControls": false,
+  "id": 2,
+  "links": [],
+  "rows": [
+    {
+      "collapse": false,
+      "height": 465,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "fill": 0,
+          "id": 1,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.*.*.data.median.firstView.SpeedIndex, 3, 4)",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "SpeedIndex",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "450",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "fill": 0,
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.*.*.data.median.firstView.requestsFull, 3, 4)"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Requests",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "fill": 0,
+          "id": 4,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode($base.$path.pageSummary.*.*.webpagetest.*.*.data.median.firstView.bytesIn, 3, 4)"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total transfer size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "${VAR_BASE}",
+          "value": "${VAR_BASE}"
+        },
+        "hide": 2,
+        "label": "${VAR_BASE}",
+        "name": "base",
+        "options": [
+          {
+            "text": "${VAR_BASE}",
+            "value": "${VAR_BASE}"
+          }
+        ],
+        "query": "${VAR_BASE}",
+        "type": "constant"
+      },
+      {
+        "current": {
+          "text": "${VAR_PATH}",
+          "value": "${VAR_PATH}"
+        },
+        "hide": 2,
+        "label": "${VAR_PATH}",
+        "name": "path",
+        "options": [
+          {
+            "text": "${VAR_PATH}",
+            "value": "${VAR_PATH}"
+          }
+        ],
+        "query": "${VAR_PATH}",
+        "type": "constant"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "WebPageTest Compare performance",
+  "version": 11
+}

--- a/dashboards/graphite/WebPageTestPageSummary.json
+++ b/dashboards/graphite/WebPageTestPageSummary.json
@@ -11,8 +11,8 @@
     {
       "name": "VAR_PATH",
       "type": "constant",
-      "label": "desktop",
-      "value": "desktop",
+      "label": "default",
+      "value": "default",
       "description": ""
     },
     {

--- a/dashboards/graphite/WebPageTestPageSummary.json
+++ b/dashboards/graphite/WebPageTestPageSummary.json
@@ -109,7 +109,7 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "datasource": "${DS_GRAPHITE}",
-          "description": "The first visual change is when something for the first time is painted within the current viewport. It is calculated by analyzing a video recording of the screen.",
+          "description": "The Start Render is when something for the first time is painted within the current viewport. It is calculated by analyzing a video recording of the screen.",
           "editable": true,
           "error": false,
           "format": "ms",
@@ -159,11 +159,11 @@
           "targets": [
             {
               "refId": "A",
-              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render"
             }
           ],
           "thresholds": "",
-          "title": "First visual change",
+          "title": "Start Render",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -235,7 +235,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex"
             }
           ],
           "thresholds": "",
@@ -314,7 +314,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85"
             }
           ],
           "thresholds": "",
@@ -390,7 +390,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete95"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete95"
             }
           ],
           "thresholds": "",
@@ -427,7 +427,7 @@
             "thresholdLabels": false,
             "thresholdMarkers": true
           },
-          "id": 61,
+          "id": 62,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -466,7 +466,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete99"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete99"
             }
           ],
           "thresholds": "",
@@ -481,19 +481,7 @@
             }
           ],
           "valueName": "current"
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": "138",
-      "panels": [
+        },
         {
           "cacheTimeout": null,
           "colorBackground": false,
@@ -554,7 +542,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange"
             }
           ],
           "thresholds": "",
@@ -569,7 +557,437 @@
             }
           ],
           "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Visual metrics",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 276,
+      "panels": [
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "description": "The moving average of the last 24 hours median values for the visual metrics.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 36,
+          "links": [],
+          "pageSize": null,
+          "scroll": false,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "span": 3,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "none"
+            }
+          ],
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "E",
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "F",
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), 11)",
+              "textEditor": false
+            }
+          ],
+          "title": "Avg last 24 hours",
+          "transform": "timeseries_aggregations",
+          "type": "table"
         },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "description": "Last 24 hours averages of median metrics compared to one day back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 37,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "span": 3,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": "cell",
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [
+                "-10",
+                "10"
+              ],
+              "type": "number",
+              "unit": "percent"
+            }
+          ],
+          "targets": [
+            {
+              "hide": true,
+              "refId": "A",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "B",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "G",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "refId": "H",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #G), #G), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "I",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "refId": "J",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "K",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "refId": "L",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')), 11)",
+              "textEditor": false
+            }
+          ],
+          "title": "Relative to yesterday",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "description": "Last 24 hours averages of median metrics compared to seven days back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 38,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "span": 3,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": "cell",
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [
+                "-10",
+                "10"
+              ],
+              "type": "number",
+              "unit": "percent"
+            }
+          ],
+          "targets": [
+            {
+              "hide": true,
+              "refId": "A",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "B",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "E",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "refId": "F",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #E), #E), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "I",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "refId": "J",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "K",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "refId": "L",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')), 11)",
+              "textEditor": false
+            }
+          ],
+          "title": "Relative to last week",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "description": "Last 24 hours averages of median metrics compared to one month back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 39,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "span": 3,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": "cell",
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [
+                "-10",
+                "10"
+              ],
+              "type": "number",
+              "unit": "percent"
+            }
+          ],
+          "targets": [
+            {
+              "hide": true,
+              "refId": "A",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "B",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "E",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "refId": "F",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #E), #E), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "I",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "refId": "J",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "K",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "refId": "L",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')), 11)",
+              "textEditor": false
+            }
+          ],
+          "title": "Relative to last month",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Visual metrics trends",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "138",
+      "panels": [
         {
           "cacheTimeout": null,
           "colorBackground": false,
@@ -617,7 +1035,7 @@
               "to": "null"
             }
           ],
-          "span": 2,
+          "span": 3,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": true,
@@ -694,7 +1112,7 @@
               "to": "null"
             }
           ],
-          "span": 2,
+          "span": 3,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": true,
@@ -705,7 +1123,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.pagexray.requests"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.requestsFull"
             }
           ],
           "thresholds": "",
@@ -770,7 +1188,7 @@
               "to": "null"
             }
           ],
-          "span": 2,
+          "span": 3,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": true,
@@ -796,13 +1214,89 @@
             }
           ],
           "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "domContentLoadedEventEnd : most of the time, your javascript waits for this event so you could consider that everything JS-dependant is available at this stage",
+          "editable": true,
+          "error": false,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 54,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domContentLoadedEventEnd"
+            }
+          ],
+          "thresholds": "",
+          "title": "Document ready",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
         }
       ],
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
+      "showTitle": true,
+      "title": "Technical metrics",
       "titleSize": "h6"
     },
     {
@@ -812,322 +1306,17 @@
         {
           "cacheTimeout": null,
           "colorBackground": false,
-          "colorValue": false,
+          "colorValue": true,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
           "datasource": "${DS_GRAPHITE}",
-          "description": "The performance score (0-100) calculated by the [Coach](https://www.sitespeed.io/documentation/coach/) using performance best practices.",
+          "description": "",
           "editable": true,
           "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 11,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.coach.advice.performance.score"
-            }
-          ],
-          "thresholds": "",
-          "title": "Performance score",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
-          "description": "The coach score (0-100) calculated by the [Coach](https://www.sitespeed.io/documentation/coach/) using best practices.",
-          "editable": true,
-          "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 62,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.coach.advice.score"
-            }
-          ],
-          "thresholds": "",
-          "title": "Coach score",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
-          "description": "The total number of iframes used on the page.",
-          "editable": true,
-          "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 23,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.iframes",
-              "textEditor": false
-            }
-          ],
-          "thresholds": "",
-          "title": "Iframes",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
-          "description": "The total number of DOM elements on the page.",
-          "editable": true,
-          "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 21,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domElements"
-            }
-          ],
-          "thresholds": "",
-          "title": "DOM Elements",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
-          "description": "The average DOM depth of the page.",
-          "editable": true,
-          "error": false,
-          "format": "none",
+          "format": "percent",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -1163,170 +1352,6 @@
               "to": "null"
             }
           ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domDepth.avg"
-            }
-          ],
-          "thresholds": "",
-          "title": "DOM depth (avg)",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
-          "description": "The max depth of DOM elements on the page.",
-          "editable": true,
-          "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 20,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domDepth.max"
-            }
-          ],
-          "thresholds": "",
-          "title": "DOM depth (max)",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 120,
-      "panels": [
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
-          "description": "In the DOM",
-          "editable": true,
-          "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 55,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
           "span": 3,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
@@ -1338,11 +1363,11 @@
           "targets": [
             {
               "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.scripts"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.score_cache"
             }
           ],
-          "thresholds": "",
-          "title": "Script tags",
+          "thresholds": "70,90",
+          "title": "Cache Static Content Score",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -1357,82 +1382,7 @@
         {
           "cacheTimeout": null,
           "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
-          "editable": true,
-          "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 15,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 3,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.pagexray.totalDomains"
-            }
-          ],
-          "thresholds": "",
-          "title": "Domains",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
+          "colorValue": true,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
@@ -1442,7 +1392,7 @@
           "description": "",
           "editable": true,
           "error": false,
-          "format": "none",
+          "format": "percent",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -1450,7 +1400,7 @@
             "thresholdLabels": false,
             "thresholdMarkers": true
           },
-          "id": 57,
+          "id": 59,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -1489,11 +1439,14 @@
           "targets": [
             {
               "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.pagexray.cookieStats"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.score_minify"
             }
           ],
-          "thresholds": "",
-          "title": "Cookies",
+          "thresholds": "70,90",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CSS/JS minification score",
+          "transparent": false,
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -1508,17 +1461,17 @@
         {
           "cacheTimeout": null,
           "colorBackground": false,
-          "colorValue": false,
+          "colorValue": true,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
           "datasource": "${DS_GRAPHITE}",
-          "description": "",
+          "description": "This score might not be meaningful if your server is on HTTP/2",
           "editable": true,
           "error": false,
-          "format": "decbytes",
+          "format": "percent",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -1526,7 +1479,7 @@
             "thresholdLabels": false,
             "thresholdMarkers": true
           },
-          "id": 56,
+          "id": 21,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -1565,11 +1518,87 @@
           "targets": [
             {
               "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.localStorageSize"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.score_combine"
             }
           ],
-          "thresholds": "",
-          "title": "Local storage size",
+          "thresholds": "70,90",
+          "title": "CSS/JS concatenation",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "",
+          "editable": true,
+          "error": false,
+          "format": "percent",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 61,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.score_gzip"
+            }
+          ],
+          "thresholds": "80,95",
+          "title": "Compression score",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -1585,431 +1614,13 @@
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
+      "showTitle": true,
+      "title": "WebPageTest scores",
       "titleSize": "h6"
     },
     {
       "collapse": false,
-      "height": 276,
-      "panels": [
-        {
-          "columns": [
-            {
-              "text": "Current",
-              "value": "current"
-            }
-          ],
-          "description": "The moving average of the last 24 hours median values for the visual metrics.",
-          "editable": true,
-          "error": false,
-          "filterNull": false,
-          "fontSize": "100%",
-          "id": 36,
-          "links": [],
-          "pageSize": null,
-          "scroll": false,
-          "showHeader": true,
-          "sort": {
-            "col": 0,
-            "desc": false
-          },
-          "span": 3,
-          "styles": [
-            {
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "pattern": "Time",
-              "type": "date"
-            },
-            {
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "decimals": 0,
-              "pattern": "/.*/",
-              "thresholds": [],
-              "type": "number",
-              "unit": "none"
-            }
-          ],
-          "targets": [
-            {
-              "refId": "A",
-              "target": "aliasByNode(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), 11)",
-              "textEditor": false
-            },
-            {
-              "refId": "B",
-              "target": "aliasByNode(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), 11)",
-              "textEditor": false
-            },
-            {
-              "refId": "D",
-              "target": "aliasByNode(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), 11)",
-              "textEditor": false
-            },
-            {
-              "refId": "E",
-              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), 11)",
-              "textEditor": false
-            },
-            {
-              "refId": "F",
-              "target": "aliasByNode(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), 11)",
-              "textEditor": false
-            }
-          ],
-          "title": "Avg last 24 hours",
-          "transform": "timeseries_aggregations",
-          "type": "table"
-        },
-        {
-          "columns": [
-            {
-              "text": "Current",
-              "value": "current"
-            }
-          ],
-          "description": "Last 24 hours averages of median metrics compared to one day back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
-          "editable": true,
-          "error": false,
-          "filterNull": false,
-          "fontSize": "100%",
-          "id": 37,
-          "links": [],
-          "pageSize": null,
-          "scroll": true,
-          "showHeader": true,
-          "sort": {
-            "col": 0,
-            "desc": false
-          },
-          "span": 3,
-          "styles": [
-            {
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "pattern": "Time",
-              "type": "date"
-            },
-            {
-              "colorMode": "cell",
-              "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-              ],
-              "decimals": 0,
-              "pattern": "/.*/",
-              "thresholds": [
-                "-10",
-                "10"
-              ],
-              "type": "number",
-              "unit": "percent"
-            }
-          ],
-          "targets": [
-            {
-              "hide": true,
-              "refId": "A",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "B",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')",
-              "textEditor": false
-            },
-            {
-              "refId": "C",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')), 11)",
-              "textEditor": false
-            },
-            {
-              "refId": "D",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "G",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')",
-              "textEditor": false
-            },
-            {
-              "refId": "H",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #G), #G), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "I",
-              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')",
-              "textEditor": false
-            },
-            {
-              "refId": "J",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "K",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')",
-              "textEditor": false
-            },
-            {
-              "refId": "L",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')), 11)",
-              "textEditor": false
-            }
-          ],
-          "title": "Relative to yesterday",
-          "transform": "timeseries_aggregations",
-          "type": "table"
-        },
-        {
-          "columns": [
-            {
-              "text": "Current",
-              "value": "current"
-            }
-          ],
-          "description": "Last 24 hours averages of median metrics compared to seven days back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
-          "editable": true,
-          "error": false,
-          "filterNull": false,
-          "fontSize": "100%",
-          "id": 38,
-          "links": [],
-          "pageSize": null,
-          "scroll": true,
-          "showHeader": true,
-          "sort": {
-            "col": 0,
-            "desc": false
-          },
-          "span": 3,
-          "styles": [
-            {
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "pattern": "Time",
-              "type": "date"
-            },
-            {
-              "colorMode": "cell",
-              "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-              ],
-              "decimals": 0,
-              "pattern": "/.*/",
-              "thresholds": [
-                "-10",
-                "10"
-              ],
-              "type": "number",
-              "unit": "percent"
-            }
-          ],
-          "targets": [
-            {
-              "hide": true,
-              "refId": "A",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "B",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')",
-              "textEditor": false
-            },
-            {
-              "refId": "C",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')), 11)",
-              "textEditor": false
-            },
-            {
-              "refId": "D",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "E",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')",
-              "textEditor": false
-            },
-            {
-              "refId": "F",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #E), #E), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "I",
-              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')",
-              "textEditor": false
-            },
-            {
-              "refId": "J",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "K",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')",
-              "textEditor": false
-            },
-            {
-              "refId": "L",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')), 11)",
-              "textEditor": false
-            }
-          ],
-          "title": "Relative to last week",
-          "transform": "timeseries_aggregations",
-          "type": "table"
-        },
-        {
-          "columns": [
-            {
-              "text": "Current",
-              "value": "current"
-            }
-          ],
-          "description": "Last 24 hours averages of median metrics compared to one month back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
-          "editable": true,
-          "error": false,
-          "filterNull": false,
-          "fontSize": "100%",
-          "id": 39,
-          "links": [],
-          "pageSize": null,
-          "scroll": true,
-          "showHeader": true,
-          "sort": {
-            "col": 0,
-            "desc": false
-          },
-          "span": 3,
-          "styles": [
-            {
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "pattern": "Time",
-              "type": "date"
-            },
-            {
-              "colorMode": "cell",
-              "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-              ],
-              "decimals": 0,
-              "pattern": "/.*/",
-              "thresholds": [
-                "-10",
-                "10"
-              ],
-              "type": "number",
-              "unit": "percent"
-            }
-          ],
-          "targets": [
-            {
-              "hide": true,
-              "refId": "A",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "B",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')",
-              "textEditor": false
-            },
-            {
-              "refId": "C",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')), 11)",
-              "textEditor": false
-            },
-            {
-              "refId": "D",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "E",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')",
-              "textEditor": false
-            },
-            {
-              "refId": "F",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #E), #E), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "I",
-              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')",
-              "textEditor": false
-            },
-            {
-              "refId": "J",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')), 11)",
-              "textEditor": false
-            },
-            {
-              "hide": true,
-              "refId": "K",
-              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')",
-              "textEditor": false
-            },
-            {
-              "refId": "L",
-              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
-              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')), 11)",
-              "textEditor": false
-            }
-          ],
-          "title": "Relative to last month",
-          "transform": "timeseries_aggregations",
-          "type": "table"
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 477,
+      "height": 455,
       "panels": [
         {
           "aliasColors": {},
@@ -2017,7 +1628,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
-          "description": "The history of First Visual Change (when something for the first time is painted within the current viewport) showing the current median value, the average median per day and the average median per week.",
+          "description": "The history of Start Render (when something for the first time is painted within the current viewport) showing the current median value, the average median per day and the average median per week.",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2058,24 +1669,24 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, 11)",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, 11)",
               "textEditor": false
             },
             {
               "refId": "B",
-              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h', 'avg', true), 'Daily')",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h', 'avg', true), 'Daily')",
               "textEditor": false
             },
             {
               "refId": "C",
-              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '7d', 'avg', true), 'Weekly ')",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '7d', 'avg', true), 'Weekly ')",
               "textEditor": false
             }
           ],
           "thresholds": [],
           "timeFrom": "30d",
           "timeShift": null,
-          "title": "History First Visual Change",
+          "title": "History Start Render",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -2156,17 +1767,17 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, 11)",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, 11)",
               "textEditor": false
             },
             {
               "refId": "B",
-              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h', 'avg', true), 'Daily')",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h', 'avg', true), 'Daily')",
               "textEditor": false
             },
             {
               "refId": "C",
-              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '7d', 'avg', true), 'Weekly')",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '7d', 'avg', true), 'Weekly')",
               "textEditor": false
             }
           ],
@@ -2206,19 +1817,7 @@
               "show": true
             }
           ]
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "VisualMetrics",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 455,
-      "panels": [
+        },
         {
           "aliasColors": {},
           "bars": false,
@@ -2266,17 +1865,17 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, 11)",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, 11)",
               "textEditor": false
             },
             {
               "refId": "B",
-              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h', 'avg', true), 'Daily')",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h', 'avg', true), 'Daily')",
               "textEditor": false
             },
             {
               "refId": "C",
-              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '7d', 'avg', true), 'Weekly')",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '7d', 'avg', true), 'Weekly')",
               "textEditor": false
             }
           ],
@@ -2316,7 +1915,19 @@
               "show": true
             }
           ]
-        },
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "History of visual metrics",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 455,
+      "panels": [
         {
           "aliasColors": {},
           "bars": false,
@@ -2358,7 +1969,7 @@
             }
           ],
           "spaceLength": 10,
-          "span": 4,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -2421,7 +2032,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
-          "description": "The history of Last Visual Change (when something for the last time is changing within the current viewport) showing the current median value, the average median per day and the average median per week.",
+          "description": "The history of DOMContentLoadedEnd",
           "editable": true,
           "error": false,
           "fill": 0,
@@ -2456,30 +2067,30 @@
             }
           ],
           "spaceLength": 10,
-          "span": 4,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, 11)",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domContentLoadedEventEnd, 11)",
               "textEditor": false
             },
             {
               "refId": "B",
-              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h', 'avg', true), 'Daily')",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domContentLoadedEventEnd, '24h', 'avg', true), 'Daily')",
               "textEditor": false
             },
             {
               "refId": "C",
-              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '7d', 'avg', true), 'Weekly')",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domContentLoadedEventEnd, '7d', 'avg', true), 'Weekly')",
               "textEditor": false
             }
           ],
           "thresholds": [],
           "timeFrom": "30d",
           "timeShift": null,
-          "title": "History Last Visual Change",
+          "title": "History Document ready",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -2517,8 +2128,8 @@
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
+      "showTitle": true,
+      "title": "History of technical metrics",
       "titleSize": "h6"
     },
     {

--- a/dashboards/graphite/WebPageTestPageSummary.json
+++ b/dashboards/graphite/WebPageTestPageSummary.json
@@ -9,6 +9,13 @@
       "pluginName": "Graphite"
     },
     {
+      "name": "VAR_PATH",
+      "type": "constant",
+      "label": "desktop",
+      "value": "desktop",
+      "description": ""
+    },
+    {
       "name": "VAR_BASE",
       "type": "constant",
       "label": "sitespeed_io",
@@ -21,7 +28,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.6.2"
+      "version": "4.5.1"
     },
     {
       "type": "panel",
@@ -40,24 +47,30 @@
       "id": "singlestat",
       "name": "Singlestat",
       "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
     }
   ],
   "annotations": {
     "list": [
       {
-        "builtIn": 1,
-        "datasource": "-- Grafana --",
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
+        "datasource": "${DS_GRAPHITE}",
+        "enable": false,
+        "iconColor": "rgb(96, 255, 113)",
+        "limit": 100,
+        "name": "runs",
+        "tags": "$base $path $domain $page $browser $connectivity",
+        "type": "alert"
       }
     ]
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 2,
   "hideControls": false,
   "id": null,
   "links": [
@@ -80,10 +93,11 @@
       "type": "dashboards"
     }
   ],
+  "refresh": false,
   "rows": [
     {
       "collapse": false,
-      "height": "25px",
+      "height": 138,
       "panels": [
         {
           "cacheTimeout": null,
@@ -95,6 +109,7 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "datasource": "${DS_GRAPHITE}",
+          "description": "The first visual change is when something for the first time is painted within the current viewport. It is calculated by analyzing a video recording of the screen.",
           "editable": true,
           "error": false,
           "format": "ms",
@@ -105,7 +120,7 @@
             "thresholdLabels": false,
             "thresholdMarkers": true
           },
-          "id": 11,
+          "id": 18,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -136,19 +151,19 @@
           "span": 2,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
+            "full": true,
             "lineColor": "rgb(31, 120, 193)",
-            "show": false
+            "show": true
           },
           "tableColumn": "",
           "targets": [
             {
               "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.TTFB"
+              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render"
             }
           ],
           "thresholds": "",
-          "title": "TTFB",
+          "title": "First visual change",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -158,7 +173,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         },
         {
           "cacheTimeout": null,
@@ -170,9 +185,10 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "datasource": "${DS_GRAPHITE}",
+          "description": "The Speed Index is the average time at which visible parts of the page are displayed. It is expressed in milliseconds and dependent on size of the view port. It was created by Pat Meenan and you can checkout the full documentation [here](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/metrics/speed-index).",
           "editable": true,
           "error": false,
-          "format": "ms",
+          "format": "none",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -180,7 +196,7 @@
             "thresholdLabels": false,
             "thresholdMarkers": true
           },
-          "id": 8,
+          "id": 58,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -211,19 +227,22 @@
           "span": 2,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
+            "full": true,
             "lineColor": "rgb(31, 120, 193)",
-            "show": false
+            "show": true
           },
           "tableColumn": "",
           "targets": [
             {
               "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.render"
+              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex"
             }
           ],
           "thresholds": "",
-          "title": "Render",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "SpeedIndex",
+          "transparent": false,
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -233,7 +252,398 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The visual complete 85% is when 85% (or more) are finished within the current viewport. It is calculated by analyzing a video recording of the screen.",
+          "editable": true,
+          "error": false,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 17,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85"
+            }
+          ],
+          "thresholds": "",
+          "title": "Visual Complete 85%",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The visual complete 95% is when 95% (or more) are finished within the current viewport. It is calculated by analyzing a video recording of the screen.",
+          "editable": true,
+          "error": false,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 60,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete95"
+            }
+          ],
+          "thresholds": "",
+          "title": "Visual Complete 95%",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The visual complete 99% is when 99% (or more) are finished within the current viewport. It is calculated by analyzing a video recording of the screen.",
+          "editable": true,
+          "error": false,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 61,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete99"
+            }
+          ],
+          "thresholds": "",
+          "title": "Visual Complete 99%",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "138",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The last visual change is when something for the last time is changing within the current viewport. It is calculated by analyzing a video recording of the screen.",
+          "editable": true,
+          "error": false,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 53,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange"
+            }
+          ],
+          "thresholds": "",
+          "title": "Last visual change",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "Fully loaded time when the last of all assets is downloaded on the page. It is calculated using the Resource Timing API where we use the last downloaded asset.",
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 43,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded",
+              "textEditor": false
+            }
+          ],
+          "thresholds": "",
+          "title": "Fully loaded",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
         },
         {
           "cacheTimeout": null,
@@ -256,7 +666,7 @@
             "thresholdLabels": false,
             "thresholdMarkers": true
           },
-          "id": 4,
+          "id": 12,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -287,19 +697,19 @@
           "span": 2,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
+            "full": true,
             "lineColor": "rgb(31, 120, 193)",
-            "show": false
+            "show": true
           },
           "tableColumn": "",
           "targets": [
             {
               "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.SpeedIndex"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.pagexray.requests"
             }
           ],
           "thresholds": "",
-          "title": "SpeedIndex",
+          "title": "Requests",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -309,7 +719,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         },
         {
           "cacheTimeout": null,
@@ -321,159 +731,10 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "datasource": "${DS_GRAPHITE}",
-          "editable": true,
-          "error": false,
-          "format": "ms",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 10,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.fullyLoaded"
-            }
-          ],
-          "thresholds": "",
-          "title": "Fully loaded",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "avg"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
+          "description": "The total transfer size over the wire (compressed size if your asset is compressed) of all assets on the page.",
           "editable": true,
           "error": false,
           "format": "bytes",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 6,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "refId": "A",
-              "target": "$base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.bytesIn"
-            }
-          ],
-          "thresholds": "",
-          "title": "Total size",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "avg"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_GRAPHITE}",
-          "editable": true,
-          "error": false,
-          "format": "none",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -512,19 +773,19 @@
           "span": 2,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
+            "full": true,
             "lineColor": "rgb(31, 120, 193)",
-            "show": false
+            "show": true
           },
           "tableColumn": "",
           "targets": [
             {
               "refId": "A",
-              "target": "sumSeries($base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.breakdown.*.requests)"
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.bytesIn"
             }
           ],
           "thresholds": "",
-          "title": "Fully requests",
+          "title": "Total transfer size",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -534,19 +795,1221 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         }
       ],
       "repeat": null,
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": false,
-      "title": "New row",
+      "title": "Dashboard Row",
       "titleSize": "h6"
     },
     {
       "collapse": false,
-      "height": "450px",
+      "height": 123,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The performance score (0-100) calculated by the [Coach](https://www.sitespeed.io/documentation/coach/) using performance best practices.",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 11,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.coach.advice.performance.score"
+            }
+          ],
+          "thresholds": "",
+          "title": "Performance score",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The coach score (0-100) calculated by the [Coach](https://www.sitespeed.io/documentation/coach/) using best practices.",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 62,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.coach.advice.score"
+            }
+          ],
+          "thresholds": "",
+          "title": "Coach score",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total number of iframes used on the page.",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 23,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.iframes",
+              "textEditor": false
+            }
+          ],
+          "thresholds": "",
+          "title": "Iframes",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total number of DOM elements on the page.",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 21,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domElements"
+            }
+          ],
+          "thresholds": "",
+          "title": "DOM Elements",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The average DOM depth of the page.",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 19,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domDepth.avg"
+            }
+          ],
+          "thresholds": "",
+          "title": "DOM depth (avg)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The max depth of DOM elements on the page.",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 20,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domDepth.max"
+            }
+          ],
+          "thresholds": "",
+          "title": "DOM depth (max)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 120,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "In the DOM",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 55,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.scripts"
+            }
+          ],
+          "thresholds": "",
+          "title": "Script tags",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 15,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.pagexray.totalDomains"
+            }
+          ],
+          "thresholds": "",
+          "title": "Domains",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 57,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.pagexray.cookieStats"
+            }
+          ],
+          "thresholds": "",
+          "title": "Cookies",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "",
+          "editable": true,
+          "error": false,
+          "format": "decbytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 56,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.localStorageSize"
+            }
+          ],
+          "thresholds": "",
+          "title": "Local storage size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 276,
+      "panels": [
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "description": "The moving average of the last 24 hours median values for the visual metrics.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 36,
+          "links": [],
+          "pageSize": null,
+          "scroll": false,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "span": 3,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "none"
+            }
+          ],
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "aliasByNode(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "E",
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "F",
+              "target": "aliasByNode(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), 11)",
+              "textEditor": false
+            }
+          ],
+          "title": "Avg last 24 hours",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "description": "Last 24 hours averages of median metrics compared to one day back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 37,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "span": 3,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": "cell",
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [
+                "-10",
+                "10"
+              ],
+              "type": "number",
+              "unit": "percent"
+            }
+          ],
+          "targets": [
+            {
+              "hide": true,
+              "refId": "A",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "B",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '1d')), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '1d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "G",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "refId": "H",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #G), #G), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '1d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "I",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "refId": "J",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '1d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "K",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')",
+              "textEditor": false
+            },
+            {
+              "refId": "L",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '1d')), 11)",
+              "textEditor": false
+            }
+          ],
+          "title": "Relative to yesterday",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "description": "Last 24 hours averages of median metrics compared to seven days back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 38,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "span": 3,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": "cell",
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [
+                "-10",
+                "10"
+              ],
+              "type": "number",
+              "unit": "percent"
+            }
+          ],
+          "targets": [
+            {
+              "hide": true,
+              "refId": "A",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "B",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '7d')), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '7d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "E",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "refId": "F",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #E), #E), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '7d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "I",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "refId": "J",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '7d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "K",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')",
+              "textEditor": false
+            },
+            {
+              "refId": "L",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '7d')), 11)",
+              "textEditor": false
+            }
+          ],
+          "title": "Relative to last week",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "description": "Last 24 hours averages of median metrics compared to one month back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "id": 39,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "span": 3,
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": "cell",
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [
+                "-10",
+                "10"
+              ],
+              "type": "number",
+              "unit": "percent"
+            }
+          ],
+          "targets": [
+            {
+              "hide": true,
+              "refId": "A",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "B",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), #A), #A), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h'), '30d')), 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "D",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), #B), #B), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h'), '30d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "E",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "refId": "F",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), #E), #E), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h'), '30d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "I",
+              "target": "timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "refId": "J",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), #I), #I), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')), timeShift(movingAverage($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h'), '30d')), 11)",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "K",
+              "target": "timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')",
+              "textEditor": false
+            },
+            {
+              "refId": "L",
+              "target": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), #K), #K), 11)",
+              "targetFull": "aliasByNode(asPercent(diffSeries(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')), timeShift(movingAverage(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h'), '30d')), 11)",
+              "textEditor": false
+            }
+          ],
+          "title": "Relative to last month",
+          "transform": "timeseries_aggregations",
+          "type": "table"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 477,
       "panels": [
         {
           "aliasColors": {},
@@ -554,45 +2017,163 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
+          "description": "The history of First Visual Change (when something for the first time is painted within the current viewport) showing the current median value, the average median per day and the average median per week.",
           "editable": true,
           "error": false,
-          "fill": 1,
+          "fill": 0,
           "grid": {},
-          "id": 1,
+          "id": 42,
           "legend": {
             "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
-            "min": false,
+            "min": true,
             "show": true,
             "total": false,
             "values": true
           },
           "lines": true,
-          "linewidth": 2,
+          "linewidth": 1,
           "links": [],
           "nullPointMode": "connected",
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "Weekly avg",
+              "fill": 0,
+              "linewidth": 2,
+              "points": true,
+              "steppedLine": true,
+              "zindex": -1
+            }
+          ],
           "spaceLength": 10,
-          "span": 12,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.{SpeedIndex,TTFB,fullyLoaded,render,loadTime}, 11)",
+              "target": "aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '24h', 'avg', true), 'Daily')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, '7d', 'avg', true), 'Weekly ')",
               "textEditor": false
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
+          "timeFrom": "30d",
           "timeShift": null,
-          "title": "Timing metrics",
+          "title": "History First Visual Change",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The history of [Speed Index](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/metrics/speed-index) showing the current median value, the average median per day and the average median per week.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 41,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Weekly avg",
+              "fill": 0,
+              "linewidth": 2,
+              "points": true,
+              "steppedLine": true,
+              "zindex": -1
+            }
+          ],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '24h', 'avg', true), 'Daily')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, '7d', 'avg', true), 'Weekly')",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeShift": null,
+          "title": "History Speed Index",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -631,12 +2212,318 @@
       "repeatIteration": null,
       "repeatRowId": null,
       "showTitle": false,
-      "title": "Row",
+      "title": "VisualMetrics",
       "titleSize": "h6"
     },
     {
       "collapse": false,
-      "height": "300px",
+      "height": 455,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The history of Visual Complete 85% (when 85% (or more) if the page in the current viewport is rendered) showing the current median value, the average median per day and the average median per week.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 44,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Weekly avg",
+              "fill": 0,
+              "linewidth": 2,
+              "points": true,
+              "steppedLine": true,
+              "zindex": -1
+            }
+          ],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '24h', 'avg', true), 'Daily')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, '7d', 'avg', true), 'Weekly')",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeShift": null,
+          "title": "History Visual Complete 85%",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The history of Fully Loaded (when the last of all assets is downloaded on the page) showing the current median value, the average median per day and the average median per week.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 45,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Weekly avg",
+              "fill": 0,
+              "linewidth": 2,
+              "points": true,
+              "steppedLine": true,
+              "zindex": -1
+            }
+          ],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '24h', 'avg', true), 'Daily')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "alias(summarize($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoaded, '7d', 'avg', true), 'Weekly')",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeShift": null,
+          "title": "History Fully Loaded",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The history of Last Visual Change (when something for the last time is changing within the current viewport) showing the current median value, the average median per day and the average median per week.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 52,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Weekly avg",
+              "fill": 0,
+              "linewidth": 2,
+              "points": true,
+              "steppedLine": true,
+              "zindex": -1
+            }
+          ],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, 11)",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '24h', 'avg', true), 'Daily')",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "alias(summarize(sitespeed_io.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, '7d', 'avg', true), 'Weekly')",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeShift": null,
+          "title": "History Last Visual Change",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "350px",
       "panels": [
         {
           "aliasColors": {
@@ -652,9 +2539,10 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
+          "description": "The total transfer size by content type.",
           "editable": true,
           "error": false,
-          "fill": 5,
+          "fill": 10,
           "grid": {},
           "id": 2,
           "legend": {
@@ -662,7 +2550,7 @@
             "avg": false,
             "current": true,
             "max": true,
-            "min": false,
+            "min": true,
             "show": true,
             "total": false,
             "values": true
@@ -683,7 +2571,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.firstView.breakdown.*.bytes, 12)"
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.breakdown.*.bytes, 12)",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -737,9 +2626,11 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
+          "decimals": 0,
+          "description": "The total number of requests by content type.",
           "editable": true,
           "error": false,
-          "fill": 5,
+          "fill": 10,
           "grid": {},
           "id": 3,
           "legend": {
@@ -747,7 +2638,7 @@
             "avg": false,
             "current": true,
             "max": true,
-            "min": false,
+            "min": true,
             "show": true,
             "total": false,
             "values": true
@@ -768,7 +2659,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.firstView.breakdown.*.requests, 12)"
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.breakdown.*.requests, 12)",
+              "textEditor": false
             }
           ],
           "thresholds": [],
@@ -827,11 +2719,195 @@
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
           "decimals": 0,
+          "description": "All requests that are not a 200 HTTP Status Code.",
           "editable": true,
           "error": false,
-          "fill": 1,
+          "fill": 5,
           "grid": {},
-          "id": 12,
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 0,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode(exclude($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.pagexray.responseCodes.*, '200'), 10)",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "None 200 response codes",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "description": "Backend : responseEnd (quand le HTML a fini d'être rapatrié)\n\n Frontend : loadEventStart",
+          "editable": true,
+          "error": false,
+          "fill": 5,
+          "grid": {},
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 0,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "B",
+              "target": "alias(asPercent($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.responseEnd, #C), 'Backend')",
+              "targetFull": "alias(asPercent($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.responseEnd, sumSeries($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart.max,$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.responseEnd.max)), 'Backend')",
+              "textEditor": false
+            },
+            {
+              "refId": "A",
+              "target": "alias(asPercent($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart, #C), 'Frontend')",
+              "targetFull": "alias(asPercent($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart, sumSeries($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart.max,$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.responseEnd.max)), 'Frontend')",
+              "textEditor": false
+            },
+            {
+              "hide": true,
+              "refId": "C",
+              "target": "sumSeries($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart,$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.responseEnd)",
+              "textEditor": true
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Time spent in backend vs frontend %",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": "",
+              "logBase": 1,
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "New row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The time the browser takes to parse the document and execute deferred and parser-inserted scripts including the network time from the users location to your server.  It is collected using the Navigation Timing API by taking the domContentLoadedEventStart minus navigationStart.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 6,
           "legend": {
             "avg": false,
             "current": true,
@@ -851,28 +2927,31 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 12,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "refId": "A",
-              "target": "alias($base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.SpeedIndex, 'Now')"
+              "target": "alias($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domContentLoadedEventEnd, 'Now')",
+              "textEditor": false
             },
             {
               "refId": "B",
-              "target": "alias(timeShift($base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.SpeedIndex, '7d'), 'One week back')"
+              "target": "alias(timeShift($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.domContentLoadedEventEnd, '7d'), 'One week back')",
+              "textEditor": false
             },
             {
+              "hide": false,
               "refId": "C",
               "target": "alias(summarize(#A, '1day', 'avg', true), \"daily avg\")",
-              "textEditor": true
+              "textEditor": false
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "SpeedIndex",
+          "title": "domContentLoadedEventEnd Time",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -889,7 +2968,109 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {
+            "max": "#BF1B00",
+            "median": "#E0752D",
+            "min": "#BF1B00"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The time it takes for the browser to parse and create the page.  It is collected using the Navigation Timing API by taking the loadEventStart minus responseEnd.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 7,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "max",
+              "fillBelowTo": "min",
+              "lines": false
+            },
+            {
+              "alias": "min",
+              "lines": false
+            }
+          ],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByMetric($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart.max)",
+              "textEditor": false
+            },
+            {
+              "refId": "B",
+              "target": "aliasByMetric($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart.median)",
+              "textEditor": false
+            },
+            {
+              "refId": "C",
+              "target": "aliasByMetric($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart.min)",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Frontend Time",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -924,17 +3105,17 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
-          "decimals": 0,
+          "description": "All User Timing marks created on the page using the [User Timing API](https://www.w3.org/TR/user-timing/).",
           "editable": true,
           "error": false,
-          "fill": 1,
+          "fill": 0,
           "grid": {},
-          "id": 13,
+          "id": 16,
           "legend": {
             "avg": false,
             "current": true,
-            "max": false,
-            "min": false,
+            "max": true,
+            "min": true,
             "show": true,
             "total": false,
             "values": true
@@ -955,13 +3136,13 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.$view.SpeedIndex, 11)"
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.userTimes.*, 10)"
             }
           ],
           "thresholds": [],
-          "timeFrom": "3M",
+          "timeFrom": null,
           "timeShift": null,
-          "title": "SpeedIndex history",
+          "title": "User timings",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -978,7 +3159,7 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "format": "ms",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1002,6 +3183,641 @@
       "showTitle": false,
       "title": "New row",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "300px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "description": "[Navigation Timing API](https://www.w3.org/TR/navigation-timing/) metrics.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "grid": {},
+          "id": 1,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.*, 12)",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Navigation Timings",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "100px",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total size over the wire for all assets served for this page.",
+          "editable": true,
+          "error": false,
+          "format": "bytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 25,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.bytesIn"
+            }
+          ],
+          "thresholds": "",
+          "title": "Total transfer size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total size over the wire for all stylesheet assets served for this page.",
+          "editable": true,
+          "error": false,
+          "format": "bytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 27,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.breakdown.css.bytes"
+            }
+          ],
+          "thresholds": "",
+          "title": "Total CSS transfer size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total size over the wire for all Javascript assets served for this page.",
+          "editable": true,
+          "error": false,
+          "format": "bytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 29,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.breakdown.js.bytes"
+            }
+          ],
+          "thresholds": "",
+          "title": "Total JS transfer size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total size for Javascripts assets served for this page. This includes the uncompressed size of JS responses.",
+          "editable": true,
+          "error": false,
+          "format": "bytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 30,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.breakdown.js.bytes"
+            }
+          ],
+          "thresholds": "",
+          "title": "Total JS content size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total size over the wire for all HTML served for this page.",
+          "editable": true,
+          "error": false,
+          "format": "bytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 46,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.breakdown.html.bytes"
+            }
+          ],
+          "thresholds": "",
+          "title": "Total HTML transfer size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total size over the wire for all font(s) served for this page.",
+          "editable": true,
+          "error": false,
+          "format": "bytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 48,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.breakdown.font.bytes"
+            }
+          ],
+          "thresholds": "",
+          "title": "Total font transfer size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_GRAPHITE}",
+          "description": "The total size for images served for this page.",
+          "editable": true,
+          "error": false,
+          "format": "bytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 50,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "refId": "A",
+              "target": "$base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.breakdown.image.bytes"
+            }
+          ],
+          "thresholds": "",
+          "title": "Total image size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "0 B",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,
@@ -1013,16 +3829,16 @@
     "list": [
       {
         "current": {
-          "value": "${VAR_BASE}",
-          "text": "${VAR_BASE}"
+          "text": "${VAR_BASE}",
+          "value": "${VAR_BASE}"
         },
         "hide": 2,
-        "label": "sitespeed_io",
+        "label": "${VAR_BASE}",
         "name": "base",
         "options": [
           {
-            "value": "${VAR_BASE}",
-            "text": "${VAR_BASE}"
+            "text": "${VAR_BASE}",
+            "value": "${VAR_BASE}"
           }
         ],
         "query": "${VAR_BASE}",
@@ -1030,7 +3846,10 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "text": "${VAR_PATH}",
+          "value": "${VAR_PATH}"
+        },
         "datasource": "${DS_GRAPHITE}",
         "hide": 0,
         "includeAll": false,
@@ -1089,6 +3908,24 @@
         "useTags": false
       },
       {
+        "current": {
+          "text": "webpagetest",
+          "value": "webpagetest"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "browser",
+        "options": [
+          {
+            "selected": true,
+            "text": "webpagetest",
+            "value": "webpagetest"
+          }
+        ],
+        "query": "webpagetest",
+        "type": "constant"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_GRAPHITE}",
@@ -1098,7 +3935,7 @@
         "multi": false,
         "name": "location",
         "options": [],
-        "query": "$base.$path.pageSummary.$domain.$page.webpagetest.*",
+        "query": "$base.$path.pageSummary.$domain.$page.$browser.*",
         "refresh": 1,
         "regex": "",
         "sort": 0,
@@ -1118,35 +3955,33 @@
         "multi": false,
         "name": "connectivity",
         "options": [],
-        "query": "$base.$path.pageSummary.$domain.$page.webpagetest.$location.*",
+        "query": "$base.$path.pageSummary.$domain.$page.$browser.$location.*",
         "refresh": 1,
         "regex": "",
         "sort": 0,
-        "tagValuesQuery": null,
+        "tagValuesQuery": "",
         "tags": [],
-        "tagsQuery": null,
+        "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
-        "current": {},
-        "datasource": "${DS_GRAPHITE}",
-        "hide": 0,
-        "includeAll": false,
+        "current": {
+          "text": "data.median.firstView",
+          "value": "data.median.firstView"
+        },
+        "hide": 2,
         "label": null,
-        "multi": false,
-        "name": "view",
-        "options": [],
-        "query": "$base.$path.pageSummary.$domain.$page.webpagetest.$location.$connectivity.data.median.*",
-        "refresh": 1,
-        "regex": "",
-        "sort": 0,
-        "tagValuesQuery": null,
-        "tags": [],
-        "tagsQuery": null,
-        "type": "query",
-        "useTags": false
+        "name": "run",
+        "options": [
+          {
+            "selected": true,
+            "text": "data.median.firstView",
+            "value": "data.median.firstView"
+          }
+        ],
+        "query": "data.median.firstView",
+        "type": "constant"
       }
     ]
   },
@@ -1180,6 +4015,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "WebPageTest page summary",
-  "version": 2
+  "title": "WebPageTest Page summary",
+  "version": 5
 }

--- a/dashboards/graphite/WebPageTestPageSummary.json
+++ b/dashboards/graphite/WebPageTestPageSummary.json
@@ -4015,6 +4015,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "WebPageTest Page summary",
+  "title": "WebPagetest Page summary",
   "version": 5
 }

--- a/dashboards/graphite/WebPageTestPageSummary.json
+++ b/dashboards/graphite/WebPageTestPageSummary.json
@@ -2155,6 +2155,7 @@
           "error": false,
           "fill": 10,
           "grid": {},
+          "height": 450,
           "id": 2,
           "legend": {
             "alignAsTable": true,
@@ -2243,6 +2244,7 @@
           "error": false,
           "fill": 10,
           "grid": {},
+          "height": 450,
           "id": 3,
           "legend": {
             "alignAsTable": true,
@@ -2410,7 +2412,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
-          "description": "Backend : responseEnd (quand le HTML a fini d'être rapatrié)\n\n Frontend : loadEventStart",
+          "description": "Backend : responseEnd (when HTML is here)\n\n Frontend : loadEventStart \n\n Available only if run with Chrome and --timeline option",
           "editable": true,
           "error": false,
           "fill": 5,
@@ -2615,8 +2617,8 @@
           "legend": {
             "avg": false,
             "current": true,
-            "max": true,
-            "min": true,
+            "max": false,
+            "min": false,
             "show": true,
             "total": false,
             "values": true
@@ -2647,17 +2649,18 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByMetric($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart.max)",
+              "target": "alias($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart, 'Now')",
               "textEditor": false
             },
             {
               "refId": "B",
-              "target": "aliasByMetric($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart.median)",
+              "target": "alias(timeShift($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart, '7d'), 'One week back')",
               "textEditor": false
             },
             {
+              "hide": false,
               "refId": "C",
-              "target": "aliasByMetric($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.chromeUserTiming.loadEventStart.min)",
+              "target": "alias(summarize(#A, '1day', 'avg', true), \"daily avg\")",
               "textEditor": false
             }
           ],
@@ -2747,7 +2750,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.userTimes.*, 10)"
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.userTimes.*, 12)"
             }
           ],
           "thresholds": [],
@@ -2805,7 +2808,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_GRAPHITE}",
-          "description": "[Navigation Timing API](https://www.w3.org/TR/navigation-timing/) metrics.",
+          "description": "If WPT has been run with chrome and the --timeline option, show the [Navigation Timing API](https://www.w3.org/TR/navigation-timing/) metrics in chromeUserTiming.",
           "editable": true,
           "error": false,
           "fill": 0,

--- a/dashboards/graphite/WebPageTestPageTimingMetrics.json
+++ b/dashboards/graphite/WebPageTestPageTimingMetrics.json
@@ -167,7 +167,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "$page — métriques visuelles",
+          "title": "$page — visual metrics",
           "tooltip": {
             "shared": false,
             "sort": 0,
@@ -278,7 +278,7 @@
         "thresholds": [],
         "timeFrom": null,
         "timeShift": null,
-        "title": "$page — mesures CPU",
+        "title": "$page — CPU consumed",
         "tooltip": {
           "shared": false,
           "sort": 0,
@@ -517,6 +517,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "WebPageTest Page timing metrics",
+  "title": "Page timing metrics",
   "version": 13
 }

--- a/dashboards/graphite/WebPageTestPageTimingMetrics.json
+++ b/dashboards/graphite/WebPageTestPageTimingMetrics.json
@@ -11,8 +11,8 @@
     {
       "name": "VAR_PATH",
       "type": "constant",
-      "label": "desktop",
-      "value": "desktop",
+      "label": "default",
+      "value": "default",
       "description": ""
     },
     {

--- a/dashboards/graphite/WebPageTestPageTimingMetrics.json
+++ b/dashboards/graphite/WebPageTestPageTimingMetrics.json
@@ -517,6 +517,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Page timing metrics",
+  "title": "Webpagetest Page timing metrics",
   "version": 13
 }

--- a/dashboards/graphite/WebPageTestPageTimingMetrics.json
+++ b/dashboards/graphite/WebPageTestPageTimingMetrics.json
@@ -1,0 +1,522 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GRAPHITE",
+      "label": "graphite",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "graphite",
+      "pluginName": "Graphite"
+    },
+    {
+      "name": "VAR_PATH",
+      "type": "constant",
+      "label": "desktop",
+      "value": "desktop",
+      "description": ""
+    },
+    {
+      "name": "VAR_BASE",
+      "type": "constant",
+      "label": "sitespeed_io",
+      "value": "sitespeed_io",
+      "description": ""
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.6.0-beta3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "graphite",
+      "name": "Graphite",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "${DS_GRAPHITE}",
+        "enable": true,
+        "iconColor": "rgb(96, 255, 103)",
+        "limit": 100,
+        "name": "runs",
+        "tags": "$base $path $domain $page $browser $connectivity",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 2,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": 593,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_GRAPHITE}",
+          "fill": 0,
+          "id": 1,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [
+            {
+              "dashUri": "db/page-summary",
+              "dashboard": "Page summary",
+              "includeVars": true,
+              "keepTime": true,
+              "targetBlank": true,
+              "title": "Page summary $page",
+              "type": "dashboard"
+            }
+          ],
+          "minSpan": 6,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "hide": false,
+              "refId": "B",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.render, 11)",
+              "textEditor": false
+            },
+            {
+              "hide": false,
+              "refId": "A",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.SpeedIndex, 11)",
+              "textEditor": false
+            },
+            {
+              "hide": false,
+              "refId": "C",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.TTFB, 11)",
+              "textEditor": false
+            },
+            {
+              "hide": false,
+              "refId": "D",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete85, 11)",
+              "textEditor": false
+            },
+            {
+              "hide": false,
+              "refId": "E",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete95, 11)",
+              "textEditor": false
+            },
+            {
+              "hide": false,
+              "refId": "F",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.visualComplete99, 11)",
+              "textEditor": false
+            },
+            {
+              "hide": false,
+              "refId": "G",
+              "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.lastVisualChange, 11)",
+              "textEditor": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$page — métriques visuelles",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "dtdurationms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Row title",
+      "titleSize": "h6"
+    },
+    {
+    "collapse": false,
+    "height": "593",
+    "panels": [
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "graphite",
+        "fill": 0,
+        "id": 2,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "max": true,
+          "min": true,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [
+          {
+            "dashUri": "db/page-summary",
+            "dashboard": "Page summary",
+            "includeVars": true,
+            "keepTime": true,
+            "targetBlank": true,
+            "title": "Page summary $page",
+            "type": "dashboard"
+          }
+        ],
+        "minSpan": 6,
+        "nullPointMode": "connected",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "span": 12,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "hide": false,
+            "refId": "B",
+            "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.docCPUms, 11)",
+            "textEditor": false
+          },
+          {
+            "hide": false,
+            "refId": "A",
+            "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.fullyLoadedCPUms, 11)",
+            "textEditor": true
+          },
+          {
+            "hide": false,
+            "refId": "C",
+            "target": "aliasByNode($base.$path.pageSummary.$domain.$page.$browser.$location.$connectivity.$run.cpuTimes.*, 12)",
+            "textEditor": true
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "$page — mesures CPU",
+        "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "transparent": false,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "dtdurationms",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ]
+      }
+    ],
+    "repeat": null,
+    "repeatIteration": null,
+    "repeatRowId": null,
+    "showTitle": false,
+    "title": "Dashboard Row",
+    "titleSize": "h6"
+  }
+
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [
+    "page",
+    "site"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "value": "${VAR_BASE}",
+          "text": "${VAR_BASE}"
+        },
+        "hide": 2,
+        "label": "sitespeed_io",
+        "name": "base",
+        "options": [
+          {
+            "value": "${VAR_BASE}",
+            "text": "${VAR_BASE}"
+          }
+        ],
+        "query": "${VAR_BASE}",
+        "type": "constant"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "path",
+        "options": [],
+        "query": "$base.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "domain",
+        "options": [],
+        "query": "$base.$path.pageSummary.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "text": "data.median.firstView",
+          "value": "data.median.firstView"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "run",
+        "options": [
+          {
+            "selected": true,
+            "text": "data.median.firstView",
+            "value": "data.median.firstView"
+          }
+        ],
+        "query": "data.median.firstView",
+        "type": "constant"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "page",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "browser",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.$page.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "location",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.$page.$browser.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "connectivity",
+        "options": [],
+        "query": "$base.$path.pageSummary.$domain.$page.$browser.$location.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "WebPageTest Page timing metrics",
+  "version": 13
+}


### PR DESCRIPTION
The goal is to have almost the same dashboards for WebPageTest results as there is for the original sitespeed.

I've : 
* copied some of the original dashboards, prefixed them with "WebPagetest" (file name and dashboard title) and adapted the graphite path to those of Webpagetest, namely
  * PageSummary
  * CompareBetweenPages
  * 3rdvs1stparty (<= this one is simplified)
* modified the WPT Page Summary

Be careful to configure the WPT test to send more metrics to graphite, here is my current configuration : 

```javascript
	filterRegistry.registerFilterForType([
		'data.median.firstView.SpeedIndex',
		'data.median.firstView.render',
		'data.median.firstView.TTFB',
		'data.median.firstView.loadTime',
		'data.median.firstView.fullyLoaded',
		'data.median.firstView.userTimes.*',
		'data.median.firstView.bytesIn',
		'data.median.firstView.breakdown.*.requests',
		'data.median.firstView.breakdown.*.bytes',
		'data.median.firstView.requestsFull',

		'data.median.firstView.custom.*',
		'data.median.firstView.domContentLoadedEventEnd',
		'data.median.firstView.fullyLoadedCPUms',
		'data.median.firstView.docCPUms',
		'data.median.firstView.score_cache',
		'data.median.firstView.score_gzip',
		'data.median.firstView.score_combine',
		'data.median.firstView.score_minify',
		'data.median.firstView.domains.*.bytes',
		'data.median.firstView.domains.*.requests',

		'data.median.firstView.domElements',
		'data.median.firstView.lastVisualChange',
		'data.median.firstView.visualComplete85',
		'data.median.firstView.visualComplete90',
		'data.median.firstView.visualComplete95',
		'data.median.firstView.visualComplete99',
		'data.median.firstView.FirstInteractive',
		'data.median.firstView.TimeToInteractive',
		'data.median.firstView.cpuTimes.*',
		'data.median.firstView.chromeUserTiming.*'
	], 'webpagetest.pageSummary')
```

* for `chromeUserTiming` to work, the WPT test must have been set with chrome and the `--timeline` option