### PR TITLE
[Feat] slightly reworked dashboard for influxdb pageSummary

### DIFF
--- a/dashboards/influxdb/pageSummary.json
+++ b/dashboards/influxdb/pageSummary.json
@@ -14,7 +14,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.4"
+      "version": "6.0.0-beta3"
+    },
+    {
+      "type": "panel",
+      "id": "grafana-piechart-panel",
+      "name": "Pie Chart",
+      "version": "1.3.3"
     },
     {
       "type": "panel",
@@ -70,9 +76,1168 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1527760167644,
+  "iteration": 1553262128009,
   "links": [],
   "panels": [
+    {
+      "aliasColors": {
+        "VisualComplete85": "dark-green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_INFLUXDB}",
+      "decimals": 2,
+      "description": "The history of First Visual Change (when something for the first time is painted within the current viewport) and Last Visual Change.",
+      "fill": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 50,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": false,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "LastVisualChange",
+          "fillBelowTo": "FirstVisualChange",
+          "lines": false
+        },
+        {
+          "alias": "FirstVisualChange",
+          "lines": false
+        },
+        {
+          "alias": "VisualComplete85",
+          "dashes": true,
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "FirstVisualChange",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "FirstVisualChange",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "median"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "median"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group",
+              "operator": "=~",
+              "value": "/^$group$/"
+            },
+            {
+              "condition": "AND",
+              "key": "page",
+              "operator": "=~",
+              "value": "/^$page$/"
+            },
+            {
+              "condition": "AND",
+              "key": "browser",
+              "operator": "=~",
+              "value": "/^$browser$/"
+            },
+            {
+              "condition": "AND",
+              "key": "connectivity",
+              "operator": "=~",
+              "value": "/^$connectivity$/"
+            },
+            {
+              "condition": "AND",
+              "key": "category",
+              "operator": "=~",
+              "value": "/^$category$/"
+            }
+          ],
+          "target": ""
+        },
+        {
+          "alias": "LastVisualChange",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "LastVisualChange",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+          "rawQuery": false,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "median"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "median"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group",
+              "operator": "=~",
+              "value": "/^$group$/"
+            },
+            {
+              "condition": "AND",
+              "key": "page",
+              "operator": "=~",
+              "value": "/^$page$/"
+            },
+            {
+              "condition": "AND",
+              "key": "browser",
+              "operator": "=~",
+              "value": "/^$browser$/"
+            },
+            {
+              "condition": "AND",
+              "key": "connectivity",
+              "operator": "=~",
+              "value": "/^$connectivity$/"
+            },
+            {
+              "condition": "AND",
+              "key": "category",
+              "operator": "=~",
+              "value": "/^$category$/"
+            }
+          ],
+          "target": ""
+        },
+        {
+          "alias": "BackendRespone",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "serverResponseTime",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+          "rawQuery": false,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "median"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "median"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group",
+              "operator": "=~",
+              "value": "/^$group$/"
+            },
+            {
+              "condition": "AND",
+              "key": "page",
+              "operator": "=~",
+              "value": "/^$page$/"
+            },
+            {
+              "condition": "AND",
+              "key": "browser",
+              "operator": "=~",
+              "value": "/^$browser$/"
+            },
+            {
+              "condition": "AND",
+              "key": "connectivity",
+              "operator": "=~",
+              "value": "/^$connectivity$/"
+            },
+            {
+              "condition": "AND",
+              "key": "category",
+              "operator": "=~",
+              "value": "/^$category$/"
+            }
+          ],
+          "target": ""
+        },
+        {
+          "alias": "VisualComplete85",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$Interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "VisualComplete85",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+          "rawQuery": false,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "median"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "median"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group",
+              "operator": "=~",
+              "value": "/^$group$/"
+            },
+            {
+              "condition": "AND",
+              "key": "page",
+              "operator": "=~",
+              "value": "/^$page$/"
+            },
+            {
+              "condition": "AND",
+              "key": "browser",
+              "operator": "=~",
+              "value": "/^$browser$/"
+            },
+            {
+              "condition": "AND",
+              "key": "connectivity",
+              "operator": "=~",
+              "value": "/^$connectivity$/"
+            },
+            {
+              "condition": "AND",
+              "key": "category",
+              "operator": "=~",
+              "value": "/^$category$/"
+            }
+          ],
+          "target": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Visual Metrics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "${DS_INFLUXDB}",
+      "description": "Total page size by loaded content types (NB! It is not transferred size)",
+      "fontSize": "80%",
+      "format": "bytes",
+      "gridPos": {
+        "h": 12,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 64,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "strokeWidth": "1",
+      "targets": [
+        {
+          "alias": "$tag_contentType",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "contentType"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "contentSize",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"contentSize\" WHERE (\"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"category\" =~ /^$category$/ AND \"contentType\" != \"\") AND $timeFilter GROUP BY time($__interval), \"contentType\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group",
+              "operator": "=~",
+              "value": "/^$group$/"
+            },
+            {
+              "condition": "AND",
+              "key": "browser",
+              "operator": "=~",
+              "value": "/^$browser$/"
+            },
+            {
+              "condition": "AND",
+              "key": "connectivity",
+              "operator": "=~",
+              "value": "/^$connectivity$/"
+            },
+            {
+              "condition": "AND",
+              "key": "page",
+              "operator": "=~",
+              "value": "/^$page$/"
+            },
+            {
+              "condition": "AND",
+              "key": "category",
+              "operator": "=~",
+              "value": "/^$category$/"
+            },
+            {
+              "condition": "AND",
+              "key": "contentType",
+              "operator": "<>",
+              "value": "\"\""
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Size by ContentType",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "${DS_INFLUXDB}",
+      "description": "",
+      "fontSize": "80%",
+      "format": "none",
+      "gridPos": {
+        "h": 12,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 66,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "strokeWidth": "1",
+      "targets": [
+        {
+          "alias": "$tag_contentType",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "contentType"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "contentSize",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"requests\" WHERE (\"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"category\" =~ /^$category$/ AND \"contentType\" != \"\") AND $timeFilter GROUP BY time($__interval), \"contentType\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group",
+              "operator": "=~",
+              "value": "/^$group$/"
+            },
+            {
+              "condition": "AND",
+              "key": "browser",
+              "operator": "=~",
+              "value": "/^$browser$/"
+            },
+            {
+              "condition": "AND",
+              "key": "connectivity",
+              "operator": "=~",
+              "value": "/^$connectivity$/"
+            },
+            {
+              "condition": "AND",
+              "key": "page",
+              "operator": "=~",
+              "value": "/^$page$/"
+            },
+            {
+              "condition": "AND",
+              "key": "category",
+              "operator": "=~",
+              "value": "/^$category$/"
+            },
+            {
+              "condition": "AND",
+              "key": "contentType",
+              "operator": "<>",
+              "value": "\"\""
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Requests by ContentType",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 71,
+      "panels": [
+        {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": 0
+          },
+          "datasource": "${DS_INFLUXDB}",
+          "fontSize": "80%",
+          "format": "decbytes",
+          "gridPos": {
+            "h": 12,
+            "w": 6,
+            "x": 0,
+            "y": 13
+          },
+          "id": 65,
+          "interval": null,
+          "legend": {
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "values": true
+          },
+          "legendType": "Under graph",
+          "links": [],
+          "maxDataPoints": 3,
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "strokeWidth": "1",
+          "targets": [
+            {
+              "alias": "$tag_contentType",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "contentType"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "contentSize",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"contentSize\" WHERE (\"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"category\" =~ /^$category$/ AND \"contentType\" <> \"\" AND \"party\" = 'firstParty') AND $timeFilter GROUP BY time($__interval), \"contentType\" fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "contentType",
+                  "operator": "<>",
+                  "value": "\"\""
+                },
+                {
+                  "condition": "AND",
+                  "key": "party",
+                  "operator": "=",
+                  "value": "firstParty"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Our size by ContentType",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": 0
+          },
+          "datasource": "${DS_INFLUXDB}",
+          "fontSize": "80%",
+          "format": "decbytes",
+          "gridPos": {
+            "h": 12,
+            "w": 6,
+            "x": 6,
+            "y": 13
+          },
+          "id": 72,
+          "interval": null,
+          "legend": {
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "values": true
+          },
+          "legendType": "Under graph",
+          "links": [],
+          "maxDataPoints": 3,
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "strokeWidth": "1",
+          "targets": [
+            {
+              "alias": "$tag_contentType",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "contentType"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "contentSize",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"contentSize\" WHERE (\"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"category\" =~ /^$category$/ AND \"contentType\" <> \"\" AND \"party\" = 'thirdParty') AND $timeFilter GROUP BY time($__interval), \"contentType\" fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "contentType",
+                  "operator": "<>",
+                  "value": "\"\""
+                },
+                {
+                  "condition": "AND",
+                  "key": "party",
+                  "operator": "=",
+                  "value": "firstParty"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "3rd size by ContentType",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": 0
+          },
+          "datasource": "${DS_INFLUXDB}",
+          "fontSize": "80%",
+          "format": "none",
+          "gridPos": {
+            "h": 12,
+            "w": 6,
+            "x": 12,
+            "y": 13
+          },
+          "id": 67,
+          "interval": null,
+          "legend": {
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "values": true
+          },
+          "legendType": "Under graph",
+          "links": [],
+          "maxDataPoints": 3,
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "strokeWidth": "1",
+          "targets": [
+            {
+              "alias": "$tag_contentType",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "contentType"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "contentSize",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"requests\" WHERE (\"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"category\" =~ /^$category$/ AND \"contentType\" <>  \"\" AND \"party\" = 'firstParty') AND $timeFilter GROUP BY time($__interval), \"contentType\" fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "contentType",
+                  "operator": "<>",
+                  "value": "\"\""
+                },
+                {
+                  "condition": "AND",
+                  "key": "party",
+                  "operator": "=",
+                  "value": "firstParty"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Our Requests by ContentType",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": 0
+          },
+          "datasource": "${DS_INFLUXDB}",
+          "fontSize": "80%",
+          "format": "none",
+          "gridPos": {
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 13
+          },
+          "id": 73,
+          "interval": null,
+          "legend": {
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "values": true
+          },
+          "legendType": "Under graph",
+          "links": [],
+          "maxDataPoints": 3,
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "strokeWidth": "1",
+          "targets": [
+            {
+              "alias": "$tag_contentType",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "contentType"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "contentSize",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"requests\" WHERE (\"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"category\" =~ /^$category$/ AND \"contentType\" <>  \"\" AND \"party\" = 'thirdParty') AND $timeFilter GROUP BY time($__interval), \"contentType\" fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "contentType",
+                  "operator": "<>",
+                  "value": "\"\""
+                },
+                {
+                  "condition": "AND",
+                  "key": "party",
+                  "operator": "=",
+                  "value": "firstParty"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "3rd Requests by ContentType",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        }
+      ],
+      "title": "Our vs 3rd party",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 55,
+      "panels": [],
+      "title": "Visual Metrics",
+      "type": "row"
+    },
     {
       "cacheTimeout": null,
       "colorBackground": false,
@@ -93,10 +1258,10 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
         "x": 0,
-        "y": 0
+        "y": 14
       },
       "id": 1,
       "interval": null,
@@ -238,10 +1403,10 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
         "x": 4,
-        "y": 0
+        "y": 14
       },
       "id": 2,
       "interval": null,
@@ -373,6 +1538,151 @@
         "rgba(50, 172, 45, 0.97)"
       ],
       "datasource": "${DS_INFLUXDB}",
+      "description": "",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 14
+      },
+      "id": 56,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "PerceptualSpeedIndex",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"median\") FROM \"SpeedIndex\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "median"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group",
+              "operator": "=~",
+              "value": "/^$group$/"
+            },
+            {
+              "condition": "AND",
+              "key": "browser",
+              "operator": "=~",
+              "value": "/^$browser$/"
+            },
+            {
+              "condition": "AND",
+              "key": "connectivity",
+              "operator": "=~",
+              "value": "/^$connectivity$/"
+            },
+            {
+              "condition": "AND",
+              "key": "page",
+              "operator": "=~",
+              "value": "/^$page$/"
+            },
+            {
+              "condition": "AND",
+              "key": "category",
+              "operator": "=~",
+              "value": "/^$category$/"
+            }
+          ],
+          "target": ""
+        }
+      ],
+      "thresholds": "",
+      "title": "Perceptual Speed Index",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_INFLUXDB}",
       "description": "The visual complete 85% is when 85% (or more) are finished within the current viewport. It is calculated by analyzing a video recording of the screen.",
       "format": "ms",
       "gauge": {
@@ -383,10 +1693,10 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
-        "x": 8,
-        "y": 0
+        "x": 12,
+        "y": 14
       },
       "id": 3,
       "interval": null,
@@ -518,6 +1828,157 @@
         "rgba(50, 172, 45, 0.97)"
       ],
       "datasource": "${DS_INFLUXDB}",
+      "description": "The visual complete 95% is when 95% (or more) are finished within the current viewport. It is calculated by analyzing a video recording of the screen.",
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 14
+      },
+      "id": 57,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "VisualComplete95",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "median"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group",
+              "operator": "=~",
+              "value": "/^$group$/"
+            },
+            {
+              "condition": "AND",
+              "key": "browser",
+              "operator": "=~",
+              "value": "/^$browser$/"
+            },
+            {
+              "condition": "AND",
+              "key": "connectivity",
+              "operator": "=~",
+              "value": "/^$connectivity$/"
+            },
+            {
+              "condition": "AND",
+              "key": "page",
+              "operator": "=~",
+              "value": "/^$page$/"
+            },
+            {
+              "condition": "AND",
+              "key": "summaryType",
+              "operator": "=",
+              "value": "pageSummary"
+            },
+            {
+              "condition": "AND",
+              "key": "category",
+              "operator": "=~",
+              "value": "/^$category$/"
+            }
+          ],
+          "target": ""
+        }
+      ],
+      "thresholds": "",
+      "title": "Visual Change 95%",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_INFLUXDB}",
       "description": "The last visual change is when something for the last time is changing within the current viewport. It is calculated by analyzing a video recording of the screen.",
       "format": "ms",
       "gauge": {
@@ -528,10 +1989,10 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 4,
-        "x": 12,
-        "y": 0
+        "x": 20,
+        "y": 14
       },
       "id": 4,
       "interval": null,
@@ -660,8731 +2121,7008 @@
       "valueName": "current"
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "Fully loaded time when the last of all assets is downloaded on the page. It is calculated using the Resource Timing API where we use the last downloaded asset.",
-      "format": "ms",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
+      "collapsed": true,
       "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 0
-      },
-      "id": 5,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "fullyLoaded",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"fullyLoaded\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Fully Loaded",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "id": 6,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "requests",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"value\") FROM \"requests\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Requests",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total transfer size over the wire (compressed size if your asset is compressed) of all assets on the page.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
+        "h": 1,
+        "w": 24,
         "x": 0,
-        "y": 3
+        "y": 18
       },
-      "id": 7,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
+      "id": 59,
+      "panels": [
         {
-          "name": "value to text",
-          "value": 1
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The moving average of the last 24 hours median values for the visual metrics.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 0,
+            "y": 19
+          },
+          "id": 43,
+          "links": [],
+          "pageSize": null,
+          "scroll": false,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "styles": [
+            {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "none"
+            }
+          ],
+          "targets": [
+            {
+              "alias": "FirstVisualChange",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "FirstVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "LastVisualChange",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "LastVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "PerceptualSpeedIndex",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "PerceptualSpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "SpeedIndex",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "SpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "D",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "VisualComplete85",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "VisualComplete85",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "E",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "FullyLoaded",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "fullyLoaded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "F",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            }
+          ],
+          "title": "Avg last 24 hours",
+          "transform": "timeseries_aggregations",
+          "type": "table"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
+          "columns": [
             {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
+              "text": "Current",
+              "value": "current"
             }
           ],
-          "measurement": "transferSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"value\") FROM \"transferSize\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'pagexray' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "description": "Last 24 hours averages of median metrics compared to one day back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 6,
+            "y": 19
+          },
+          "hideTimeOverride": true,
+          "id": 47,
+          "links": [],
+          "pageSize": null,
+          "scroll": false,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "styles": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "pagexray"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "none"
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total Transfer Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size for all assets served for this page. This includes the uncompressed size for compressed text/css/html/js/font content.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 3
-      },
-      "id": 13,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "targets": [
+            {
+              "alias": "FirstVisualChange",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "FirstVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT moving_average(\"mean\", 10) FROM \"FirstVisualChange\" WHERE \"category\" =~ /^$category$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "LastVisualChange",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "LastVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "PerceptualSpeedIndex",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "PerceptualSpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "SpeedIndex",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "SpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "D",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "VisualComplete85",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "VisualComplete85",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "E",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "FullyLoaded",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "fullyLoaded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "F",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            }
+          ],
+          "timeShift": "1d",
+          "title": "Relative to yesterday",
+          "transform": "timeseries_aggregations",
+          "type": "table"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
+          "columns": [
             {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
+              "text": "Current",
+              "value": "current"
             }
           ],
-          "measurement": "contentSize",
-          "query": "SELECT last(\"value\") FROM \"contentSize\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'pagexray' AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "description": "Last 24 hours averages of median metrics compared to seven days back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 12,
+            "y": 19
+          },
+          "hideTimeOverride": true,
+          "id": 48,
+          "links": [],
+          "pageSize": null,
+          "scroll": false,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "styles": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "pagexray"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "none"
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total Content Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The performance score (0-100) calculated by the [Coach](https://www.sitespeed.io/documentation/coach/) using performance best practices.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 3
-      },
-      "id": 12,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "targets": [
+            {
+              "alias": "FirstVisualChange",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "FirstVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "LastVisualChange",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "LastVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "PerceptualSpeedIndex",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "PerceptualSpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "SpeedIndex",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "SpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "D",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "VisualComplete85",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "VisualComplete85",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "E",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "FullyLoaded",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "fullyLoaded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "F",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": "7d",
+          "title": "Relative to last week",
+          "transform": "timeseries_aggregations",
+          "type": "table"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
+          "columns": [
             {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
+              "text": "Current",
+              "value": "current"
             }
           ],
-          "measurement": "score",
-          "query": "SELECT last(\"value\") FROM \"score\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"advice\" = 'performance' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "description": "Last 24 hours averages of median metrics compared to one month back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
+          "editable": true,
+          "error": false,
+          "filterNull": false,
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 19
+          },
+          "id": 49,
+          "links": [],
+          "pageSize": null,
+          "scroll": false,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": false
+          },
+          "styles": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "advice",
-              "operator": "=",
-              "value": "performance"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 0,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "none"
             }
           ],
-          "target": ""
+          "targets": [
+            {
+              "alias": "FirstVisualChange",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "FirstVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "40"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "LastVisualChange",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "LastVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "40"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "PerceptualSpeedIndex",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "PerceptualSpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "40"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "SpeedIndex",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "SpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "D",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "40"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "VisualComplete85",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "VisualComplete85",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "E",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "40"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            },
+            {
+              "alias": "FullyLoaded",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "fullyLoaded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "F",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "mean"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "40"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ],
+              "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
+              "textEditor": false
+            }
+          ],
+          "title": "Relative to last month",
+          "transform": "timeseries_aggregations",
+          "type": "table"
         }
       ],
-      "thresholds": "",
-      "title": "Performance score",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
+      "title": "Visual Metric Trends",
+      "type": "row"
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total number of DOM elements on the page.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
+      "collapsed": true,
       "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 3
-      },
-      "id": 14,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "domElements",
-          "query": "SELECT last(\"value\") FROM \"domElements\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "coach"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "DOM Elements",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The document height in pixels.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 3
-      },
-      "id": 15,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "documentHeight",
-          "query": "SELECT last(\"value\") FROM \"documentHeight\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "coach"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Document height",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total number of iframes used on the page.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 3
-      },
-      "id": 16,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "iframes",
-          "query": "SELECT last(\"value\") FROM \"iframes\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "coach"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "IFrames",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The average DOM depth of the page.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
+        "h": 1,
+        "w": 24,
         "x": 0,
-        "y": 6
+        "y": 19
       },
-      "id": 17,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
+      "id": 62,
+      "panels": [
         {
-          "name": "value to text",
-          "value": 1
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "decimals": 2,
+          "description": "The history of First Visual Change (when something for the first time is painted within the current viewport) showing the current median value, the average median per day and the average median per week.",
+          "fill": 1,
+          "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 8,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Median",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "FirstVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "Daily",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "FirstVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND $timeFilter AND  time > now() - 7d GROUP BY time(1d)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "Weekly",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "7d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "FirstVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "First Visual Change",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The history of [Speed Index](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/metrics/speed-index) showing the current median value, the average median per day and the average median per week.",
+          "fill": 1,
+          "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 9,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-              "params": [
-                "$__interval"
+              "alias": "Median",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "time"
+              "measurement": "SpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"SpeedIndex\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             },
             {
-              "params": [
-                "null"
+              "alias": "Daily",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "fill"
+              "measurement": "SpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"SpeedIndex\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "Weekly",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "7d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "SpeedIndex",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"SpeedIndex\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             }
           ],
-          "measurement": "domDepth",
-          "query": "SELECT last(\"value\") FROM \"iframes\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "avg"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Speed Index",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "coach"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "DOM depth (avg)",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The max depth of DOM elements on the page.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 6
-      },
-      "id": 18,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "decimals": 2,
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 38
+          },
+          "id": 10,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-              "params": [
-                "$__interval"
+              "alias": "Median",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "time"
+              "measurement": "VisualComplete85",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"VisualComplete85\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             },
             {
-              "params": [
-                "null"
+              "alias": "Daily",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "fill"
+              "measurement": "VisualComplete85",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"VisualComplete85\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "Weekly",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "7d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "VisualComplete85",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"VisualComplete85\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             }
           ],
-          "measurement": "domDepth",
-          "query": "SELECT last(\"avg\") FROM \"domDepth\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "max"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Visual Complete 85%",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "coach"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "DOM depth (max)",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "Script tags in the DOM.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 6
-      },
-      "id": 19,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "decimals": 2,
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 38
+          },
+          "id": 11,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-              "params": [
-                "$__interval"
+              "alias": "Median",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "time"
+              "measurement": "LastVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             },
             {
-              "params": [
-                "null"
+              "alias": "Weekly",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "fill"
+              "measurement": "LastVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "Monthly",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "7d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "LastVisualChange",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             }
           ],
-          "measurement": "scripts",
-          "query": "SELECT last(\"max\") FROM \"domDepth\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Last Visual Change",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "coach"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Script tags",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 6
-      },
-      "id": 20,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "decimals": 2,
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 38
+          },
+          "id": 25,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
             {
-              "params": [
-                "$__interval"
+              "alias": "Median",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "time"
+              "measurement": "fullyLoaded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             },
             {
-              "params": [
-                "null"
+              "alias": "Weekly",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "fill"
+              "measurement": "fullyLoaded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"fullyLoaded\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "Monthly",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "7d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "fullyLoaded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"fullyLoaded\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             }
           ],
-          "measurement": "totalDomains",
-          "query": "SELECT last(\"value\") FROM \"scripts\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "thresholds": [],
+          "timeFrom": "30d",
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Fully Loaded",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "pagexray"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             }
           ],
-          "target": ""
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "thresholds": "",
-      "title": "Domains",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
+      "title": "History of Visual Metrics",
+      "type": "row"
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
+      "collapsed": true,
       "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 6
-      },
-      "id": 21,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "cookieStats",
-          "query": "SELECT last(\"median\") FROM \"cookieStats\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'pagexray' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "pagexray"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Cookies",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 6
-      },
-      "id": 22,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "localStorageSize",
-          "query": "SELECT last(\"median\") FROM \"cookieStats\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'pagexray' AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "summaryType",
-              "operator": "=",
-              "value": "pageSummary"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "coach"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Local storage size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        }
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The moving average of the last 24 hours median values for the visual metrics.",
-      "editable": true,
-      "error": false,
-      "filterNull": false,
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 7,
-        "w": 6,
+        "h": 1,
+        "w": 24,
         "x": 0,
-        "y": 9
+        "y": 20
       },
-      "id": 43,
-      "links": [],
-      "pageSize": null,
-      "scroll": false,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": false
-      },
-      "styles": [
+      "id": 53,
+      "panels": [
         {
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "colorMode": null,
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "decimals": 0,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "none"
-        }
-      ],
-      "targets": [
-        {
-          "alias": "FirstVisualChange",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "FirstVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  10
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "LastVisualChange",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "LastVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  10
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "PerceptualSpeedIndex",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "PerceptualSpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  10
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "SpeedIndex",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "SpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "D",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  10
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "VisualComplete85",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "VisualComplete85",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "E",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  10
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "FullyLoaded",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "fullyLoaded",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "F",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  10
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        }
-      ],
-      "title": "Avg last 24 hours",
-      "transform": "timeseries_aggregations",
-      "type": "table"
-    },
-    {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        }
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "Last 24 hours averages of median metrics compared to one day back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
-      "editable": true,
-      "error": false,
-      "filterNull": false,
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 9
-      },
-      "hideTimeOverride": true,
-      "id": 47,
-      "links": [],
-      "pageSize": null,
-      "scroll": false,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": false
-      },
-      "styles": [
-        {
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 0,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "none"
-        }
-      ],
-      "targets": [
-        {
-          "alias": "FirstVisualChange",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "FirstVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT moving_average(\"mean\", 10) FROM \"FirstVisualChange\" WHERE \"category\" =~ /^$category$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "LastVisualChange",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "LastVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "PerceptualSpeedIndex",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "PerceptualSpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "SpeedIndex",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "SpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "D",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "VisualComplete85",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "VisualComplete85",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "E",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "FullyLoaded",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "fullyLoaded",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "F",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        }
-      ],
-      "timeShift": "1d",
-      "title": "Relative to yesterday",
-      "transform": "timeseries_aggregations",
-      "type": "table"
-    },
-    {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        }
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "Last 24 hours averages of median metrics compared to seven days back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
-      "editable": true,
-      "error": false,
-      "filterNull": false,
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 9
-      },
-      "hideTimeOverride": true,
-      "id": 48,
-      "links": [],
-      "pageSize": null,
-      "scroll": false,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": false
-      },
-      "styles": [
-        {
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 0,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "none"
-        }
-      ],
-      "targets": [
-        {
-          "alias": "FirstVisualChange",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "FirstVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "LastVisualChange",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "LastVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "PerceptualSpeedIndex",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "PerceptualSpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "SpeedIndex",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "SpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "D",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "VisualComplete85",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "VisualComplete85",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "E",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "FullyLoaded",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "fullyLoaded",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "F",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "10"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": "7d",
-      "title": "Relative to last week",
-      "transform": "timeseries_aggregations",
-      "type": "table"
-    },
-    {
-      "columns": [
-        {
-          "text": "Current",
-          "value": "current"
-        }
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "Last 24 hours averages of median metrics compared to one month back in time. \n\nRed color background means a regression, green a positive change and yellow that the change is within the margin of error. You probably need to finetune the thresholds depending of how flakey your site is. Default threshold is +-10%.",
-      "editable": true,
-      "error": false,
-      "filterNull": false,
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 9
-      },
-      "id": 49,
-      "links": [],
-      "pageSize": null,
-      "scroll": false,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": false
-      },
-      "styles": [
-        {
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 0,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "none"
-        }
-      ],
-      "targets": [
-        {
-          "alias": "FirstVisualChange",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "FirstVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "40"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "LastVisualChange",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "LastVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "40"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "PerceptualSpeedIndex",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "PerceptualSpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "40"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "SpeedIndex",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "SpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "D",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "40"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "VisualComplete85",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "VisualComplete85",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "E",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "40"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        },
-        {
-          "alias": "FullyLoaded",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "fullyLoaded",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "F",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [
-                  "40"
-                ],
-                "type": "moving_average"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ],
-          "target": "aliasByNode(movingAverage($base.$path.pageSummary.$group.$page.$browser.$connectivity.browsertime.statistics.visualMetrics.SpeedIndex.$function, '24h'), 10)",
-          "textEditor": false
-        }
-      ],
-      "title": "Relative to last month",
-      "transform": "timeseries_aggregations",
-      "type": "table"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "decimals": 2,
-      "description": "The history of First Visual Change (when something for the first time is painted within the current viewport) showing the current median value, the average median per day and the average median per week.",
-      "fill": 1,
-      "gridPos": {
-        "h": 11,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "id": 8,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Median",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1h"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "FirstVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Daily",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "FirstVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND $timeFilter AND  time > now() - 7d GROUP BY time(1d)",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Weekly",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "7d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "FirstVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": "30d",
-      "timeShift": null,
-      "title": "First Visual Change",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
+          "datasource": "${DS_INFLUXDB}",
+          "description": "Fully loaded time when the last of all assets is downloaded on the page. It is calculated using the Resource Timing API where we use the last downloaded asset.",
           "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 21
+          },
+          "id": 5,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "fullyLoaded",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"median\") FROM \"fullyLoaded\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "Fully Loaded",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The history of [Speed Index](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/metrics/speed-index) showing the current median value, the average median per day and the average median per week.",
-      "fill": 1,
-      "gridPos": {
-        "h": 11,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
-      "id": 9,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Median",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1h"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "measurement": "SpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"SpeedIndex\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Daily",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "SpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"SpeedIndex\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Weekly",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "7d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "SpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"SpeedIndex\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": "30d",
-      "timeShift": null,
-      "title": "Speed Index",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
+          "datasource": "${DS_INFLUXDB}",
           "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 21
+          },
+          "id": 6,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "requests",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"requests\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "Requests",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "decimals": 2,
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 0,
-        "y": 27
-      },
-      "id": 10,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Median",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1h"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "measurement": "VisualComplete85",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"VisualComplete85\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Daily",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "VisualComplete85",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"VisualComplete85\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Weekly",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "7d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "VisualComplete85",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"VisualComplete85\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": "30d",
-      "timeShift": null,
-      "title": "Visual Complete 85%",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "decimals": 2,
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 8,
-        "y": 27
-      },
-      "id": 11,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Median",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1h"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "LastVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Weekly",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "LastVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Monthly",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "7d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "LastVisualChange",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": "30d",
-      "timeShift": null,
-      "title": "Last Visual Change",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "decimals": 2,
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 16,
-        "y": 27
-      },
-      "id": 25,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Median",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1h"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "fullyLoaded",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"LastVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Weekly",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "fullyLoaded",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"fullyLoaded\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "Monthly",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "7d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "fullyLoaded",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"fullyLoaded\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": "30d",
-      "timeShift": null,
-      "title": "Fully Loaded",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": true,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "fill": 1,
-      "gridPos": {
-        "h": 13,
-        "w": 12,
-        "x": 0,
-        "y": 36
-      },
-      "id": 23,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": false,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "$tag_contentType",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "contentType"
-              ],
-              "type": "tag"
-            }
-          ],
-          "measurement": "contentSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"contentSize\" WHERE  \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"origin\" = 'pagexray' AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY \"contentType\"",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "pagexray"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Size",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The total transfer size over the wire (compressed size if your asset is compressed) of all assets on the page.",
           "format": "decbytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 21
+          },
+          "id": 7,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "transferSize",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"transferSize\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'pagexray' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "pagexray"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "Total Transfer Size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": true,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "fill": 1,
-      "gridPos": {
-        "h": 13,
-        "w": 12,
-        "x": 12,
-        "y": 36
-      },
-      "id": 24,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": false,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "$tag_contentType",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "contentType"
-              ],
-              "type": "tag"
-            }
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "measurement": "requests",
-          "query": "SELECT \"value\" FROM \"requests\" WHERE  \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"origin\" = 'pagexray' AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY \"contentType\"",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "pagexray"
-            }
-          ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Requests",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The performance score (0-100) calculated by the [Coach](https://www.sitespeed.io/documentation/coach/) using performance best practices.",
           "format": "none",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "description": "All requests that are not a 200 HTTP Status Code.",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 49
-      },
-      "id": 30,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Non 200",
-          "dsType": "influxdb",
-          "groupBy": [
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 21
+          },
+          "id": 12,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-              "params": [
-                "$__interval"
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
+              "measurement": "score",
+              "query": "SELECT last(\"value\") FROM \"score\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"advice\" = 'performance' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
               ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "200",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "origin",
-              "operator": "=",
-              "value": "pagexray"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "None 200 Response Codes",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": true,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The max time spent in frontend vs backend time. \\n\\nThe backend time is the time it takes for the network and the server to generate and start sending the HTML. It is collected using the Navigation Timing API taking the responseStart minus navigationStart.\\n\\nThe frontend time is the time it takes for the browser to parse and create the page.  It is collected using the Navigation Timing API by taking the loadEventStart minus responseEnd.",
-      "fill": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 49
-      },
-      "id": 31,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": false,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": true,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "Frontend"
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Backend",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "backEndTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ]
-        },
-        {
-          "alias": "Frontend",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "frontEndTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Time spent in backend vs frontend % [median]",
-      "tooltip": {
-        "shared": false,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": [
-          "total"
-        ]
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The time the browser takes to parse the document and execute deferred and parser-inserted scripts including the network time from the users location to your server.  It is collected using the Navigation Timing API by taking the domContentLoadedEventStart minus navigationStart.",
-      "fill": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 56
-      },
-      "id": 26,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "daily",
-          "fill": 2,
-          "linewidth": 0
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "median",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1h"
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "advice",
+                  "operator": "=",
+                  "value": "performance"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
               ],
-              "type": "time"
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "Performance score",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The document height in pixels.",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 21
+          },
+          "id": 15,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
             },
             {
-              "params": [
-                "null"
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "domContentLoadedTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"value\") FROM \"domContentLoadedTime\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "daily",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1d"
+              "measurement": "documentHeight",
+              "query": "SELECT last(\"value\") FROM \"documentHeight\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
               ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "coach"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
               ],
-              "type": "fill"
+              "target": ""
             }
           ],
-          "measurement": "domContentLoadedTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"domContentLoadedTime\" WHERE \"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
+          "thresholds": "",
+          "title": "Document height",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
             {
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "time",
-              "operator": ">",
-              "value": "now() - 7d"
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "DOMContentLoaded Time",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "valueName": "avg"
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {
-        "max": "#890F02",
-        "min": "#890F02"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The time it takes for the browser to parse and create the page.  It is collected using the Navigation Timing API by taking the loadEventStart minus responseEnd.",
-      "fill": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 56
-      },
-      "id": 27,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "max",
-          "fillBelowTo": "min",
-          "lines": false
-        },
-        {
-          "alias": "min",
-          "lines": false
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "max",
-          "dsType": "influxdb",
-          "groupBy": [
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The total number of DOM elements on the page.",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 21
+          },
+          "id": 14,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-              "params": [
-                "1h"
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
+              "measurement": "domElements",
+              "query": "SELECT last(\"value\") FROM \"domElements\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
               ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "frontEndTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"max\") FROM \"frontEndTime\" WHERE \"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": true,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "max"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "median",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1h"
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "coach"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
               ],
-              "type": "time"
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "DOM Elements",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The total number of iframes used on the page.",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 2,
+            "x": 0,
+            "y": 25
+          },
+          "id": 16,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
             },
             {
-              "params": [
-                "null"
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
               ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "frontEndTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"median\") FROM \"frontEndTime\" WHERE \"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            }
-          ],
-          "target": ""
-        },
-        {
-          "alias": "min",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "1h"
+              "measurement": "iframes",
+              "query": "SELECT last(\"value\") FROM \"iframes\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
               ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "coach"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
               ],
-              "type": "fill"
+              "target": ""
             }
           ],
-          "measurement": "frontEndTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT median(\"min\") FROM \"frontEndTime\" WHERE \"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time(1h) fill(null)",
-          "rawQuery": false,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "min"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "median"
-              }
-            ]
-          ],
-          "tags": [
+          "thresholds": "",
+          "title": "IFrames",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
             {
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Frontend Time",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "valueName": "avg"
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "description": "All User Timing marks created on the page using the [User Timing API](https://www.w3.org/TR/user-timing/)",
-      "fill": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 63
-      },
-      "id": 29,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "Now Current",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "domContentLoadedTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              }
-            ]
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The avg depth of DOM elements on the page.",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 2,
+            "y": 25
+          },
+          "id": 60,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "name": "value to text",
+              "value": 1
             },
             {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=",
-              "value": "_"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ]
-        },
-        {
-          "alias": "One Week Back Current",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "domContentLoadedTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "mean"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=",
-              "value": "_"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "User Timings",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_INFLUXDB}",
-      "description": "[Navigation Timing API](https://www.w3.org/TR/navigation-timing/) metrics.",
-      "fill": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 70
-      },
-      "id": 28,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": true,
-        "min": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "backendTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "backEndTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "backEndTime"
-            }
-          ]
-        },
-        {
-          "alias": "domContentLoadedTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "domContentLoadedTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "domContentLoadedTime"
-            }
-          ]
-        },
-        {
-          "alias": "domInteractiveTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "domInteractiveTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "domInteractiveTime"
-            }
-          ]
-        },
-        {
-          "alias": "domainLookupTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "domainLookupTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "D",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "domainLookupTime"
-            }
-          ]
-        },
-        {
-          "alias": "frontEndTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "frontEndTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "E",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "frontEndTime"
-            }
-          ]
-        },
-        {
-          "alias": "pageDownloadTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "pageDownloadTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "F",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "pageDownloadTime"
-            }
-          ]
-        },
-        {
-          "alias": "pageLoadTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "pageLoadTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "G",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "pageLoadTime"
-            }
-          ]
-        },
-        {
-          "alias": "redirectionTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "redirectionTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "H",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "redirectionTime"
-            }
-          ]
-        },
-        {
-          "alias": "serverConnectionTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "serverConnectionTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "I",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "serverConnectionTime"
-            }
-          ]
-        },
-        {
-          "alias": "serverResponseTime",
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "serverResponseTime",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "J",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "pageTimings",
-              "operator": "=",
-              "value": "serverResponseTime"
-            }
-          ]
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Navigation Timings",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size for stylesheets assets served for this page. This includes the uncompressed size of CSS responses.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 77
-      },
-      "id": 32,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "contentSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
-            {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "css"
+              "name": "range to text",
+              "value": 2
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total CSS Content Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size over the wire for all stylesheet assets served for this page.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 77
-      },
-      "id": 33,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "transferSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "css"
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total CSS Transfert Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size for Javascripts assets served for this page. This includes the uncompressed size of JS responses.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 77
-      },
-      "id": 34,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "contentSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "javascript"
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "domDepth",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"avg\") FROM \"domDepth\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "avg"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "coach"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total JS Content Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size over the wire for all Javascript assets served for this page.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 77
-      },
-      "id": 35,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "transferSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "thresholds": "",
+          "title": "DOM depth (avg)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "javascript"
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total JS Transfer Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size for HTML served for this page. This includes the uncompressed size of HTML.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 77
-      },
-      "id": 36,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "valueName": "avg"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "contentSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The max depth of DOM elements on the page.",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 6,
+            "y": 25
+          },
+          "id": 18,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "name": "value to text",
+              "value": 1
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "html"
+              "name": "range to text",
+              "value": 2
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total HTML Content Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size over the wire for all HTML served for this page.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 77
-      },
-      "id": 37,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "domDepth",
+              "query": "SELECT last(\"avg\") FROM \"domDepth\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "max"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "coach"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "DOM depth (max)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "transferSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "format": "decbytes",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 10,
+            "y": 25
+          },
+          "id": 22,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "name": "value to text",
+              "value": 1
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "html"
+              "name": "range to text",
+              "value": 2
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total HTML Transfer Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size for font(s) served for this page. This includes the uncompressed size.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 80
-      },
-      "id": 38,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "localStorageSize",
+              "query": "SELECT last(\"median\") FROM \"cookieStats\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'pagexray' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "coach"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "Local storage size",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "contentSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "description": "Script tags in the DOM.",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 14,
+            "y": 25
+          },
+          "id": 19,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "name": "value to text",
+              "value": 1
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "font"
+              "name": "range to text",
+              "value": 2
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total Font Content Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size over the wire for all font(s) served for this page.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 80
-      },
-      "id": 39,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "scripts",
+              "query": "SELECT last(\"max\") FROM \"domDepth\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "coach"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "Script tags",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "transferSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 2,
+            "x": 18,
+            "y": 25
+          },
+          "id": 21,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "name": "value to text",
+              "value": 1
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "font"
+              "name": "range to text",
+              "value": 2
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total Font Transfer Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size for images served for this page.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 80
-      },
-      "id": 40,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cookieStats",
+              "query": "SELECT last(\"median\") FROM \"cookieStats\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'pagexray' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "pagexray"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "Cookies",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "contentSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
           ],
-          "tags": [
+          "datasource": "${DS_INFLUXDB}",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 25
+          },
+          "id": 20,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
+              "name": "value to text",
+              "value": 1
             },
             {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "image"
+              "name": "range to text",
+              "value": 2
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total Images Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "The total size for other elements served for this page.",
-      "format": "decbytes",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 80
-      },
-      "id": 41,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "totalDomains",
+              "query": "SELECT last(\"value\") FROM \"scripts\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"summaryType\" = 'pageSummary' AND \"origin\" = 'coach' AND $timeFilter GROUP BY time($__interval) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "summaryType",
+                  "operator": "=",
+                  "value": "pageSummary"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "pagexray"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": "",
+          "title": "Domains",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "transferSize",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "fill": 1,
+          "gridPos": {
+            "h": 13,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 23,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
-            },
-            {
-              "condition": "AND",
-              "key": "contentType",
-              "operator": "=",
-              "value": "other"
+              "alias": "$tag_contentType",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "contentType"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "measurement": "contentSize",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"value\" FROM \"contentSize\" WHERE (\"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"origin\" = 'pagexray' AND contentType != \"\") AND $timeFilter GROUP BY \"contentType\"",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "pagexray"
+                }
+              ],
+              "target": ""
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "Total Other Transfer Size",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "${DS_INFLUXDB}",
-      "description": "Calculate SpeedIndex measurements using Resource Timings",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 80
-      },
-      "id": 42,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "dsType": "influxdb",
-          "groupBy": [],
-          "measurement": "rumSpeedIndex",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT last(\"median\") FROM \"FirstVisualChange\" WHERE \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time($__interval) fill(null)",
-          "rawQuery": false,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "median"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": [
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "fill": 1,
+          "gridPos": {
+            "h": 13,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 24,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
             {
-              "key": "group",
-              "operator": "=~",
-              "value": "/^$group$/"
-            },
-            {
-              "condition": "AND",
-              "key": "browser",
-              "operator": "=~",
-              "value": "/^$browser$/"
-            },
-            {
-              "condition": "AND",
-              "key": "connectivity",
-              "operator": "=~",
-              "value": "/^$connectivity$/"
-            },
-            {
-              "condition": "AND",
-              "key": "page",
-              "operator": "=~",
-              "value": "/^$page$/"
-            },
-            {
-              "condition": "AND",
-              "key": "category",
-              "operator": "=~",
-              "value": "/^$category$/"
+              "alias": "$tag_contentType",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "contentType"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "measurement": "requests",
+              "query": "SELECT \"value\" FROM \"requests\" WHERE  \"group\" =~ /^$group$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"page\" =~ /^$page$/ AND \"origin\" = 'pagexray' AND \"category\" =~ /^$category$/ AND $timeFilter GROUP BY \"contentType\"",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "pagexray"
+                }
+              ],
+              "target": ""
             }
           ],
-          "target": ""
-        }
-      ],
-      "thresholds": "",
-      "title": "RUM Speed Index",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Requests",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
         {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "description": "All requests that are not a 200 HTTP Status Code.",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 30,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Non 200",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "200",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "origin",
+                  "operator": "=",
+                  "value": "pagexray"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "None 200 Response Codes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The max time spent in frontend vs backend time. \\n\\nThe backend time is the time it takes for the network and the server to generate and start sending the HTML. It is collected using the Navigation Timing API taking the responseStart minus navigationStart.\\n\\nThe frontend time is the time it takes for the browser to parse and create the page.  It is collected using the Navigation Timing API by taking the loadEventStart minus responseEnd.",
+          "fill": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 31,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": true,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Frontend"
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Backend",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "backEndTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ]
+            },
+            {
+              "alias": "Frontend",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "frontEndTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time spent in backend vs frontend % [median]",
+          "tooltip": {
+            "shared": false,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [
+              "total"
+            ]
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The time the browser takes to parse the document and execute deferred and parser-inserted scripts including the network time from the users location to your server.  It is collected using the Navigation Timing API by taking the domContentLoadedEventStart minus navigationStart.",
+          "fill": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 49
+          },
+          "id": 26,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "daily",
+              "fill": 2,
+              "linewidth": 0
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "median",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "domContentLoadedTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"value\") FROM \"domContentLoadedTime\" WHERE \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND \"browser\" =~ /^$browser$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"category\" =~ /^$category$/ AND $timeFilter AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "daily",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1d"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "domContentLoadedTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"domContentLoadedTime\" WHERE \"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "time",
+                  "operator": ">",
+                  "value": "now() - 7d"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "DOMContentLoaded Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "max": "#890F02",
+            "min": "#890F02"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "description": "The time it takes for the browser to parse and create the page.  It is collected using the Navigation Timing API by taking the loadEventStart minus responseEnd.",
+          "fill": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 49
+          },
+          "id": 27,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "max",
+              "fillBelowTo": "min",
+              "lines": false
+            },
+            {
+              "alias": "min",
+              "lines": false
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "max",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "frontEndTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"max\") FROM \"frontEndTime\" WHERE \"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": true,
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "max"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "median",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "frontEndTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"median\") FROM \"frontEndTime\" WHERE \"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                }
+              ],
+              "target": ""
+            },
+            {
+              "alias": "min",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "1h"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "frontEndTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"min\") FROM \"frontEndTime\" WHERE \"browser\" =~ /^$browser$/ AND \"category\" =~ /^$category$/ AND \"connectivity\" =~ /^$connectivity$/ AND \"group\" =~ /^$group$/ AND \"page\" =~ /^$page$/ AND $timeFilter GROUP BY time(1h) fill(null)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "min"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "median"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                }
+              ],
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Frontend Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_INFLUXDB}",
+          "description": "[Navigation Timing API](https://www.w3.org/TR/navigation-timing/) metrics.",
+          "fill": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 56
+          },
+          "id": 28,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "backendTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "backEndTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "backEndTime"
+                }
+              ]
+            },
+            {
+              "alias": "domContentLoadedTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "domContentLoadedTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "domContentLoadedTime"
+                }
+              ]
+            },
+            {
+              "alias": "domInteractiveTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "domInteractiveTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "domInteractiveTime"
+                }
+              ]
+            },
+            {
+              "alias": "domainLookupTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "domainLookupTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "D",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "domainLookupTime"
+                }
+              ]
+            },
+            {
+              "alias": "frontEndTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "frontEndTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "E",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "frontEndTime"
+                }
+              ]
+            },
+            {
+              "alias": "pageDownloadTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "pageDownloadTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "F",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "pageDownloadTime"
+                }
+              ]
+            },
+            {
+              "alias": "pageLoadTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "pageLoadTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "G",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "pageLoadTime"
+                }
+              ]
+            },
+            {
+              "alias": "redirectionTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "redirectionTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "H",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "redirectionTime"
+                }
+              ]
+            },
+            {
+              "alias": "serverConnectionTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "serverConnectionTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "I",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "serverConnectionTime"
+                }
+              ]
+            },
+            {
+              "alias": "serverResponseTime",
+              "dsType": "influxdb",
+              "groupBy": [],
+              "measurement": "serverResponseTime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "J",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "median"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "category",
+                  "operator": "=~",
+                  "value": "/^$category$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "group",
+                  "operator": "=~",
+                  "value": "/^$group$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "page",
+                  "operator": "=~",
+                  "value": "/^$page$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "browser",
+                  "operator": "=~",
+                  "value": "/^$browser$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "connectivity",
+                  "operator": "=~",
+                  "value": "/^$connectivity$/"
+                },
+                {
+                  "condition": "AND",
+                  "key": "pageTimings",
+                  "operator": "=",
+                  "value": "serverResponseTime"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Navigation Timings",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
-      "valueName": "avg"
+      "title": "Technical Metrics",
+      "type": "row"
     }
   ],
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "frontend"
+  ],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {},
         "datasource": "${DS_INFLUXDB}",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -9394,6 +9132,7 @@
         "query": "SHOW TAG VALUES WITH KEY = \"category\"",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -9405,6 +9144,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_INFLUXDB}",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "group",
@@ -9414,6 +9154,7 @@
         "query": "SHOW TAG VALUES WITH KEY = \"group\" WHERE \"category\" =~ /$category/",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -9425,6 +9166,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_INFLUXDB}",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -9434,6 +9176,7 @@
         "query": "SHOW TAG VALUES WITH KEY = \"page\" WHERE \"group\" =~ /$group/ AND \"category\" =~ /$category/",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -9445,6 +9188,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_INFLUXDB}",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -9454,6 +9198,7 @@
         "query": "SHOW TAG VALUES WITH KEY = \"browser\" WHERE \"group\" =~ /$group/ AND \"page\"  =~ /$page/ AND \"category\" =~ /$category/",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -9465,6 +9210,7 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_INFLUXDB}",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -9474,17 +9220,81 @@
         "query": "SHOW TAG VALUES WITH KEY = \"connectivity\" WHERE \"group\" =~ /$group/ AND \"page\"  =~ /$page/ AND \"browser\" =~ /$browser/ AND \"category\" =~ /$category/",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "15m",
+          "value": "15m"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "Interval",
+        "options": [
+          {
+            "selected": true,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "15m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
       }
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
Hello, sitespeed.io team.

I see, that there are a lot of work for dashboard in graphite, but influxdb is behind the scene both in the metrics and in the dashboard. I've made some changes to influxdb dashboard to clean view with rows and pie charts:
![Page summary InfluxDB](https://user-images.githubusercontent.com/2872741/54833311-ea562980-4cce-11e9-9153-79f0a6048a20.png)


* Add piechart for contentType and requests charts